### PR TITLE
Show "rape_legacy" data when the crime is "rape" for now

### DIFF
--- a/src/components/TrendContainer.js
+++ b/src/components/TrendContainer.js
@@ -23,7 +23,7 @@ const TrendContainer = ({
   if (loading) content = <Loading />
   else {
     const data = mungeSummaryData({
-      crime: snakeCase(crime),
+      crime: snakeCase((crime === 'rape') ? 'rape_legacy' : crime),
       summaries: summaries.data,
       place,
       since,


### PR DESCRIPTION
We should have two lines on the trend chart for rape (per place), one
for the revised definition and one for the legacy definition