### PR TITLE
Add more Google analytics tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prettier": "prettier --single-quote --trailing-comma all --semi false --write \"{src,test}/**/*.js\""
   },
   "dependencies": {
+    "autotrack": "^2.3.2",
     "axios": "^0.15.3",
     "babel-polyfill": "^6.20.0",
     "basic-auth-connect": "^1.0.0",

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,3 +1,5 @@
+import 'autotrack/lib/plugins/outbound-link-tracker'
+import 'autotrack/lib/plugins/url-change-tracker'
 import 'babel-polyfill'
 import 'element-closest'
 

--- a/src/html.js
+++ b/src/html.js
@@ -2,8 +2,19 @@
 
 import sharingMetaTags from './util/sharing'
 
-const isProd = process.env.NODE_ENV === 'production'
-const analytics = `<script>!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),ga("create","UA-48605964-47","auto"),ga("set","anonymizeIp",!0),ga("set","forceSSL",!0),ga("send","pageview");</script>
+const analytics = `
+<script>
+!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),
+ga("create","UA-48605964-47","auto"),
+
+ga("require", "outboundLinkTracker"),
+ga("require", "urlChangeTracker"),
+
+ga("set","anonymizeIp",!0),
+ga("set","forceSSL",!0),
+ga("send","pageview");
+</script>
+
 <script src='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js' id='_fed_an_ua_tag'></script>`
 
 export default (content, state) =>
@@ -23,7 +34,7 @@ export default (content, state) =>
         window.__STATE__ = ${JSON.stringify(state).replace(/</g, '\\u003c')}
       </script>
       <script src='/bundle.js'></script>
-      ${isProd ? analytics : ''}
+      ${process.env.NODE_ENV === 'production' ? analytics : ''}
     </body>
   </html>
 `

--- a/src/html.js
+++ b/src/html.js
@@ -2,6 +2,10 @@
 
 import sharingMetaTags from './util/sharing'
 
+const isProd = process.env.NODE_ENV === 'production'
+const analytics = `<script>!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),ga("create","UA-48605964-47","auto"),ga("set","anonymizeIp",!0),ga("set","forceSSL",!0),ga("send","pageview");</script>
+<script src='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js' id='_fed_an_ua_tag'></script>`
+
 export default (content, state) =>
   `
   <!DOCTYPE html>
@@ -19,8 +23,7 @@ export default (content, state) =>
         window.__STATE__ = ${JSON.stringify(state).replace(/</g, '\\u003c')}
       </script>
       <script src='/bundle.js'></script>
-      <script>!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),ga("create","UA-48605964-47","auto"),ga("set","anonymizeIp",!0),ga("set","forceSSL",!0),ga("send","pageview");</script>
-      <script src='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js' id='_fed_an_ua_tag'></script>
+      ${isProd ? analytics : ''}
     </body>
   </html>
 `

--- a/src/html.js
+++ b/src/html.js
@@ -1,21 +1,5 @@
-/* eslint-disable max-len */
-
 import sharingMetaTags from './util/sharing'
-
-const analytics = `
-<script>
-!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),
-ga("create","UA-48605964-47","auto"),
-
-ga("require", "outboundLinkTracker"),
-ga("require", "urlChangeTracker"),
-
-ga("set","anonymizeIp",!0),
-ga("set","forceSSL",!0),
-ga("send","pageview");
-</script>
-
-<script src='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js' id='_fed_an_ua_tag'></script>`
+import analytics from './util/analytics'
 
 export default (content, state) =>
   `

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -1,0 +1,15 @@
+export default `
+  <script>
+  !function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),
+  ga("create","UA-48605964-47","auto"),
+
+  ga("require", "outboundLinkTracker"),
+  ga("require", "urlChangeTracker"),
+
+  ga("set","anonymizeIp",!0),
+  ga("set","forceSSL",!0),
+  ga("send","pageview");
+  </script>
+
+  <script src='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js' id='_fed_an_ua_tag'></script>
+`

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -14,51 +14,49 @@ var config = {
   entry: './src/entry.js',
   output: {
     path: path.join(__dirname, 'build'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   module: {
     loaders: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
-        loader: 'babel'
+        exclude: /node_modules\/(?!autotrack|dom-utils)/,
+        loader: 'babel',
       },
       {
         test: /\.json$/,
-        loader: 'json'
+        loader: 'json',
       },
       {
         test: /\.scss$/i,
-        loader: ExtractTextPlugin.extract(['css', 'postcss', 'sass'])
+        loader: ExtractTextPlugin.extract(['css', 'postcss', 'sass']),
       },
       {
         test: /\.ya*ml$/,
-        loaders: ['json', 'yaml']
-      }
-    ]
+        loaders: ['json', 'yaml'],
+      },
+    ],
   },
   sassLoader: {
     outputStyle: 'compressed',
-    includePaths: ['node_modules']
+    includePaths: ['node_modules'],
   },
-  postcss: [
-    autoprefixer({ browsers: ['last 2 versions', '> 5%'] })
-  ],
+  postcss: [autoprefixer({ browsers: ['last 2 versions', '> 5%'] })],
   plugins: [
     new CompressionPlugin({
       asset: '[path].gz[query]',
       algorithm: 'gzip',
       test: /\.js$/,
       threshold: 10240,
-      minRatio: 0.8
+      minRatio: 0.8,
     }),
     new ExtractTextPlugin('app.css'),
     new webpack.DefinePlugin({
       'process.env': {
-        'NODE_ENV': JSON.stringify(env)
-      }
-    })
-  ]
+        NODE_ENV: JSON.stringify(env),
+      },
+    }),
+  ],
 }
 
 if (env === 'production') {

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -6,42 +6,43 @@ var path = require('path')
 var webpack = require('webpack')
 
 var nodeModules = {}
-fs.readdirSync('node_modules')
+fs
+  .readdirSync('node_modules')
   .filter(x => ['.bin'].indexOf(x) === -1)
-  .forEach(mod => { nodeModules[mod] = `commonjs ${mod}` })
+  .forEach(mod => {
+    nodeModules[mod] = `commonjs ${mod}`
+  })
 
 var config = {
   cache: false,
   entry: './src/server.js',
   output: {
     path: path.join(__dirname, 'build'),
-    filename: 'server.js'
+    filename: 'server.js',
   },
   target: 'node',
   node: {
-    __dirname: false
+    __dirname: false,
   },
   externals: nodeModules,
   module: {
     loaders: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
-        loader: 'babel'
+        exclude: /node_modules\/(?!autotrack|dom-utils)/,
+        loader: 'babel',
       },
       {
         test: /\.json$/,
-        loader: 'json'
+        loader: 'json',
       },
       {
         test: /\.ya*ml$/,
-        loaders: ['json', 'yaml']
-      }
-    ]
+        loaders: ['json', 'yaml'],
+      },
+    ],
   },
-  plugins: [
-    new webpack.IgnorePlugin(/\.(css|less)$/),
-  ]
+  plugins: [new webpack.IgnorePlugin(/\.(css|less)$/)],
 }
 
 module.exports = config


### PR DESCRIPTION
Add [`autotrack`](https://github.com/googleanalytics/autotrack) so that URL changes in the single page app are still tracked in Google Analytics. It would be good to implement the following other autotrack plugins, but they shouldn't necessarily hold up merging:
- [`impressionTracker`](https://github.com/googleanalytics/autotrack/blob/master/docs/plugins/impression-tracker.md)
- [`maxScrollTracker`](https://github.com/googleanalytics/autotrack/blob/master/docs/plugins/max-scroll-tracker.md)
- [`mediaQueryTracker`](https://github.com/googleanalytics/autotrack/blob/master/docs/plugins/media-query-tracker.md)
- [`pageVisibilityTracker`](https://github.com/googleanalytics/autotrack/blob/master/docs/plugins/page-visibility-tracker.md)

Closes 18F/crime-data-explorer#72