### PR TITLE
Use data filtered by year before making total NIBRS incident count

### DIFF
--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -52,7 +52,7 @@ const NibrsContainer = ({ crime, dispatch, nibrs, place, since, until }) => {
   if (!loading && data) {
     const filteredData = filterNibrsData(data, { since, until })
     const dataParsed = parseNibrs(filteredData)
-    totalCount = data.offenderRaceCode.reduce((a, b) => a + b.count, 0)
+    totalCount = filteredData.offenderRaceCode.reduce((a, b) => a + b.count, 0)
     content = (
       <div className="clearfix mxn1">
         {dataParsed.map((d, i) => (


### PR DESCRIPTION
Fix an issue where NIBRS incidents counts (in the initial NIBRS paragraph) can be significantly higher than the other numbers in the interface. For example, using rape offenses in Alabama (`/explorer/state/alabama/rape`) it showed that there were over 3K incidents for the time period between 2004 and 2014. In fact, we weren't respecting the `since` or `until` dates and the numbers for the early 1990s in Alabama are really high. Now the number in the paragraph is much closer to the other numbers in the NIBRS cards.

API response:
```
    {
      "count": 661,
      "year": "1991",
      "offense_name": "rape",
      "race_code": "B"
    },
    {
      "count": 659,
      "year": "1991",
      "offense_name": "rape",
      "race_code": "U"
    },
    {
      "count": 296,
      "year": "1991",
      "offense_name": "rape",
      "race_code": "W"
    }
```

Before:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/1M2D2t1X2r2F3c0B3m1G/Screen%20Shot%202017-05-05%20at%2011.32.42%20AM.png)

After:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/0g1N1n1G470J1C0l3c3R/Screen%20Shot%202017-05-05%20at%2011.32.23%20AM.png)