### PR TITLE
Do not prevent all defaults on click events from <AboutTheData />

### DIFF
--- a/src/components/AboutTheData.js
+++ b/src/components/AboutTheData.js
@@ -15,11 +15,13 @@ class AboutTheData extends React.Component {
   }
 
   triggerGlossaryTerm = e => {
-    e.preventDefault()
     const { target } = e
 
     if (!target.closest('.about-the-data .caveats')) return
     if (!target.href || !target.href.match(/#glossary\?term=/)) return
+
+    // only prevent default if the click event is a glossary term link
+    e.preventDefault()
 
     const term = lowerCase(target.href.split('term=')[1])
     this.props.onTermClick(term)


### PR DESCRIPTION
Because these event listeners are attached to the document, we have to be careful about only preventing defaults when the event matches the requisite elements. This manifested as the sidebar crime filters not responding to click events