### PR TITLE
Sort summary data by date

### DIFF
--- a/src/util/summary.js
+++ b/src/util/summary.js
@@ -7,6 +7,7 @@ const mungeSummaryData = ({ crime, summaries, place, since, until }) => {
       if (!since || !until) return true
       return d.year >= since && d.year <= until
     })
+    .sort((a, b) => new Date(a.year) - new Date(b.year))
     .map(year => {
       const data = { date: year.year }
       keys.forEach(key => {

--- a/src/util/summary.js
+++ b/src/util/summary.js
@@ -7,7 +7,7 @@ const mungeSummaryData = ({ crime, summaries, place, since, until }) => {
       if (!since || !until) return true
       return d.year >= since && d.year <= until
     })
-    .sort((a, b) => new Date(a.year) - new Date(b.year))
+    .sort((a, b) => a.year - b.year)
     .map(year => {
       const data = { date: year.year }
       keys.forEach(key => {

--- a/test/util/summary.test.js
+++ b/test/util/summary.test.js
@@ -36,6 +36,26 @@ describe('summary data munging utility', () => {
     expect(actual.length).toEqual(2)
   })
 
+  it('should sort the data by date', () => {
+    const data = [
+      { year: 2011, 'violent-crime': 10, population: 100 },
+      { year: 2013, 'violent-crime': 10, population: 100 },
+      { year: 2012, 'violent-crime': 10, population: 100 },
+    ]
+
+    const actual = mungeSummaryData({
+      crime: 'violent-crime',
+      summaries: { california: data, 'united-states': data },
+      place: 'california',
+      since: 2011,
+      until: 2013,
+    })
+    const actualYears = actual.map(a => a.date)
+
+    expect(actualYears[0]).toEqual(2011)
+    expect(actualYears[2]).toEqual(2013)
+  })
+
   it('should reshape the data', () => {
     const crime = 'violent-crime'
     const summaries = {


### PR DESCRIPTION
Fix problem where trend line was doubling back on itself.

Before:
<img width="886" alt="screen shot 2017-05-07 at 7 56 39 pm" src="https://cloud.githubusercontent.com/assets/780941/25792768/809ed81e-337d-11e7-8ff8-326f97ba2ea4.png">

After:
<img width="809" alt="screen shot 2017-05-07 at 11 38 07 pm" src="https://cloud.githubusercontent.com/assets/780941/25792896/4445c5d4-337e-11e7-93b5-cbd1600e5087.png">
