### PR TITLE
refine trend chart

### DIFF
--- a/sass/components/_forms.scss
+++ b/sass/components/_forms.scss
@@ -4,7 +4,6 @@
   padding-top: .25rem;
 }
 
-
 // custom select inputs (with chevron arrow)
 
 .select {
@@ -26,6 +25,13 @@
   color: $white;
 }
 
+.select-sm {
+  background-position: center right .5rem;
+  background-size: .5rem .5rem;
+  height: 1.5rem;
+  line-height: 1;
+  padding: 0 .5rem;
+}
 
 // subset of wtf-forms
 // http://wtfforms.com/

--- a/sass/components/_viz.scss
+++ b/sass/components/_viz.scss
@@ -1,15 +1,16 @@
 .axis {
   fill: none;
   font-family: $font-monospace;
-  font-size: $h6;
+  font-size: 10px;
 
   line,
   path {
     stroke: $blue-light;
-    stroke-opacity: .25;
     stroke-width: 1px;
   }
 }
+
+.axis--y text { text-anchor: start; }
 
 .usa-map path {
   stroke: $white;

--- a/sass/util/_space-addon.scss
+++ b/sass/util/_space-addon.scss
@@ -147,5 +147,6 @@
 @media #{$breakpoint-lg} {
   .lg-mb0 { margin-bottom: 0; }
   .lg-ml3 { margin-left: $space-3; }
+  .lg-pr5 { padding-right: $space-5; }
   .lg-px8 { padding-left: $space-8; padding-right: $space-8; }
 }

--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -78,7 +78,7 @@ const NibrsContainer = ({ crime, dispatch, nibrs, place, since, until }) => {
   return (
     <div>
       <div className="mb2 p2 sm-p4 bg-white border-top border-blue border-w8">
-        <h2 className="mt0 mb1 fs-24 sm-fs-32 sans-serif">
+        <h2 className="mt0 mb1 fs-24 sm-fs-28 sans-serif">
           {startCase(crime)} incident details in {startCase(place)}
         </h2>
         {nibrsFirstYear !== since &&

--- a/src/components/NibrsHistogram.js
+++ b/src/components/NibrsHistogram.js
@@ -95,7 +95,7 @@ class NibrsHistogram extends React.Component {
 }
 
 NibrsHistogram.defaultProps = {
-  margin: { top: 5, right: 10, bottom: 20, left: 5 },
+  margin: { top: 5, right: 10, bottom: 24, left: 5 },
   size: { width: 360, height: 160 },
 }
 

--- a/src/components/TimePeriodFilter.js
+++ b/src/components/TimePeriodFilter.js
@@ -1,10 +1,7 @@
 import PropTypes from 'prop-types'
-import range from 'lodash.range'
 import React from 'react'
 
-const MIN_YEAR = 1995
-const MAX_YEAR = 2014
-const YEAR_RANGE = range(MIN_YEAR, MAX_YEAR + 1)
+import { YEAR_RANGE } from '../util/years'
 
 class TimePeriodFilter extends React.Component {
   state = { error: null }

--- a/src/components/TrendChart.js
+++ b/src/components/TrendChart.js
@@ -84,6 +84,7 @@ class TrendChart extends React.Component {
         date: d.date,
         value: d[k.slug],
       }))
+      const ends = [values[0], values[values.length - 1]]
 
       values.forEach(d => {
         if (d.value.count !== 0) {
@@ -94,7 +95,7 @@ class TrendChart extends React.Component {
         }
       })
 
-      return { id: k.slug, name: k.name, values, segments }
+      return { id: k.slug, name: k.name, ends, segments, values }
     })
 
     const gapRanges = gaps.map(year =>
@@ -103,9 +104,9 @@ class TrendChart extends React.Component {
 
     const maxValue = max(dataByKey, d => max(d.values, v => v.value.rate))
 
+    const { margin } = size
     const svgWidth = svgParentWidth || size.width
     const svgHeight = svgWidth / 2.25
-    const margin = { ...size.margin, left: maxValue > 1000 ? 48 : 36 }
     const width = svgWidth - margin.left - margin.right
     const height = svgHeight - margin.top - margin.bottom
     const xPadding = svgWidth < 500 ? 20 : 40
@@ -132,7 +133,12 @@ class TrendChart extends React.Component {
 
     const callout = (
       <g transform={`translate(${x(active.date)}, 0)`}>
-        <line y2={height} stroke="#95aabc" strokeWidth="1" />
+        <line
+          y2={height}
+          stroke="#95aabc"
+          strokeDasharray="2,3"
+          strokeWidth="1"
+        />
         {keysWithSlugs.map((k, j) => (
           <circle
             key={j}
@@ -154,11 +160,11 @@ class TrendChart extends React.Component {
           dispatch={dispatch}
           keys={keysWithSlugs}
         />
-        <div className="mb1 fs-12 bold monospace">
+        <div className="mb3 fs-10 bold monospace black">
           {startCase(crime)} rate per 100,000 people
         </div>
         {/* eslint-disable no-return-assign */}
-        <div className="col-12" ref={ref => (this.svgParent = ref)}>
+        <div className="mb3 col-12" ref={ref => (this.svgParent = ref)}>
           {gapRanges.length > 0 &&
             <div className="mb1 fs-12 serif italic">
               <span
@@ -179,6 +185,7 @@ class TrendChart extends React.Component {
                 />
               ))}
               <XAxis
+                active={active && active.date}
                 scale={x}
                 height={height}
                 tickCt={svgWidth < 500 ? 4 : 8}
@@ -206,6 +213,15 @@ class TrendChart extends React.Component {
                         ))}
                     </g>
                   ))}
+                  {d.ends.map((datum, j) => (
+                    <circle
+                      key={j}
+                      cx={x(datum.date)}
+                      cy={y(datum.value.rate)}
+                      fill={color(d.id)}
+                      r="3"
+                    />
+                  ))}
                 </g>
               ))}
               {until >= 2013 &&
@@ -213,12 +229,7 @@ class TrendChart extends React.Component {
                 <g
                   transform={`translate(${x(new Date('2013-01-01'))}, ${height})`}
                 >
-                  <line
-                    stroke="#95aabc"
-                    strokeWidth="1"
-                    strokeDasharray="2,3"
-                    y2={-height}
-                  />
+                  <line stroke="#95aabc" strokeWidth="1" y2={-height} />
                   <rect
                     className="fill-blue"
                     height="8"
@@ -255,9 +266,6 @@ class TrendChart extends React.Component {
             </g>
           </svg>
         </div>
-        <div className="my1 fs-10 sm-fs-12 italic monospace center">
-          (Crime counts include FBI estimates; rates are rounded)
-        </div>
       </div>
     )
   }
@@ -272,9 +280,9 @@ TrendChart.propTypes = {
 TrendChart.defaultProps = {
   size: {
     width: 735,
-    margin: { top: 16, right: 0, bottom: 24, left: 36 },
+    margin: { top: 16, right: 0, bottom: 24, left: 32 },
   },
-  colors: ['#ff5e50', '#52687d', '#97a7b8'],
+  colors: ['#ff5e50', '#95aabc', '#52687d'],
   showMarkers: false,
 }
 

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -33,6 +33,9 @@ const TrendChartDetails = ({ colors, crime, data, dispatch, keys }) => {
   const rate = data[slug].rate
   const year = data.date.getFullYear()
 
+  const borderColor = { borderColor: '#c8d3dd' }
+  const cellStyle = { width: 68, ...borderColor }
+
   const isOnlyNational = keys.length === 1
   const term = (
     <Term dispatch={dispatch} id={mapCrimeToGlossaryTerm(crime)}>
@@ -41,49 +44,42 @@ const TrendChartDetails = ({ colors, crime, data, dispatch, keys }) => {
   )
 
   return (
-    <div className="mb3 lg-flex">
+    <div className="mb3 sm-mb5 lg-flex">
       <div className="flex-auto">
-        <h4 className="mt0 mb1 fs-18 sans-serif">{year}</h4>
-        <p className="mb1 lg-m0 lg-pr4 lg-mh-72p fs-14 sm-fs-16">
+        <p className="mb1 lg-m0 lg-pr5 lg-mh-72p fs-14">
           {isOnlyNational &&
             <span>
-              There were
-              {' '}
-              {highlight(formatRate(rate))}
-              {' '}
-              incidents of
-              {' '}
-              {term}
-              {' '}
+              There were{' '}
+              {highlight(formatRate(rate))}{' '}
+              incidents of {term}{' '}
               per 100,000 people.
             </span>}
           {!isOnlyNational &&
             <span>
-              {name}
-              ’s
-              {' '}
-              {term}
-              {' '}
-              rate was
-              {' '}
-              {comparison}
-              {' '}
-              that of the United States, and
-              in {highlight(year)} was {highlight(formatRate(rate))} incidents
+              {name}’s {term} rate was {comparison}{' '}
+              that of the United States, and in{' '}
+              {highlight(year)} was {highlight(formatRate(rate))} incidents
               per 100,000 people.
             </span>}
         </p>
       </div>
-      <div>
-        <table className="mb1 lg-m0 p2 md-p3 col-12 sm-col-5 bg-blue-white">
-          <thead className="fs-12 line-height-3">
-            <tr><td /><td>Rate</td><td>Total</td></tr>
+      <div className="flex-none overflow-auto">
+        <table className="mb1 lg-m0 p2 col-12 sm-col-5 bg-blue-white">
+          <thead className="fs-10 line-height-4 right-align">
+            <tr>
+              <td />
+              <td className="pr2">Rate</td>
+              <td className="pr2">Total</td>
+              <td className="pl2 border-left" style={borderColor}>
+                Population
+              </td>
+            </tr>
           </thead>
-          <tbody className="fs-14 bold">
+          <tbody className="fs-12 bold line-height-4">
             {keys.map((k, i) => (
               <tr key={i}>
                 <td
-                  className="pr2 sm-pr3 fs-12 nowrap truncate align-bottom"
+                  className="pr2 nowrap truncate align-bottom"
                   style={{ maxWidth: 125 }}
                 >
                   <span
@@ -96,20 +92,31 @@ const TrendChartDetails = ({ colors, crime, data, dispatch, keys }) => {
                   />
                   {k.name}
                 </td>
-                <td className="pt1 pr2 sm-pr3 line-height-4 align-bottom">
+                <td className="pt1 pr2 align-bottom right-align">
                   <span
-                    className="inline-block border-bottom border-blue-light border-w2"
-                    style={{ width: 72 }}
+                    className="inline-block border-bottom"
+                    style={cellStyle}
                   >
                     {formatRate(data[k.slug].rate)}
                   </span>
                 </td>
-                <td className="pt1 line-height-4 align-bottom">
+                <td className="pt1 pr2 align-bottom right-align">
                   <span
-                    className="inline-block border-bottom border-blue-light border-w2"
-                    style={{ width: 72 }}
+                    className="inline-block border-bottom"
+                    style={cellStyle}
                   >
                     {formatTotal(data[k.slug].count)}
+                  </span>
+                </td>
+                <td
+                  className="pt1 pl2 align-bottom right-align border-left"
+                  style={borderColor}
+                >
+                  <span
+                    className="inline-block border-bottom"
+                    style={cellStyle}
+                  >
+                    {formatTotal(data[k.slug].pop)}
                   </span>
                 </td>
               </tr>

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -1,4 +1,5 @@
 import { format } from 'd3-format'
+import range from 'lodash.range'
 import lowerCase from 'lodash.lowercase'
 import React from 'react'
 
@@ -27,11 +28,22 @@ const getComparison = ({ place, data }) => {
       </span>
 }
 
-const TrendChartDetails = ({ colors, crime, data, dispatch, keys }) => {
+const TrendChartDetails = ({
+  colors,
+  crime,
+  data,
+  dispatch,
+  keys,
+  since,
+  updateYear,
+  until,
+}) => {
   const { name, slug } = keys[0]
   const comparison = getComparison({ place: slug, data })
   const rate = data[slug].rate
   const year = data.date.getFullYear()
+  const yearRange = range(since, until + 1)
+  const handleSelectChange = e => updateYear(Number(e.target.value))
 
   const borderColor = { borderColor: '#c8d3dd' }
   const cellStyle = { width: 68, ...borderColor }
@@ -56,10 +68,9 @@ const TrendChartDetails = ({ colors, crime, data, dispatch, keys }) => {
             </span>}
           {!isOnlyNational &&
             <span>
-              {name}’s {term} rate was {comparison}{' '}
-              that of the United States, and in{' '}
-              {highlight(year)} was {highlight(formatRate(rate))} incidents
-              per 100,000 people.
+              In {highlight(year)}, {name}’s {term} rate was{' '}
+              {highlight(formatRate(rate))} incidents per 100,000 people,
+              which was {comparison} that of the United States.
             </span>}
         </p>
       </div>
@@ -67,10 +78,23 @@ const TrendChartDetails = ({ colors, crime, data, dispatch, keys }) => {
         <table className="mb1 lg-m0 p2 col-12 sm-col-5 bg-blue-white">
           <thead className="fs-10 line-height-4 right-align">
             <tr>
-              <td />
-              <td className="pr2">Rate</td>
-              <td className="pr2">Total</td>
-              <td className="pl2 border-left" style={borderColor}>
+              <td className="left-align">
+                <label htmlFor="year-selected" className="hide">
+                  Year selected
+                </label>
+                <select
+                  className="col-12 field select select-sm select-dark fs-12"
+                  id="year-selected"
+                  style={{ width: 100 }}
+                  onChange={handleSelectChange}
+                  value={year}
+                >
+                  {yearRange.map((y, i) => <option key={i}>{y}</option>)}
+                </select>
+              </td>
+              <td className="pr2 align-middle">Rate</td>
+              <td className="pr2 align-middle">Total</td>
+              <td className="pl2 align-middle border-left" style={borderColor}>
                 Population
               </td>
             </tr>

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -61,7 +61,7 @@ const TrendChartDetails = ({
         <p className="mb1 lg-m0 lg-pr5 lg-mh-72p fs-14">
           {isOnlyNational &&
             <span>
-              There were{' '}
+              In {highlight(year)}, there were{' '}
               {highlight(formatRate(rate))}{' '}
               incidents of {term}{' '}
               per 100,000 people.

--- a/src/components/TrendContainer.js
+++ b/src/components/TrendContainer.js
@@ -71,9 +71,8 @@ const TrendContainer = ({
   return (
     <div>
       <div className="mb2 p2 sm-p4 bg-white border-top border-blue border-w8">
-        <h2 className="mt0 mb3 fs-24 sm-fs-32 sans-serif">
+        <h2 className="mt0 mb3 sm-mb5 fs-24 sm-fs-28 sans-serif">
           {startCase(crime)} rate in {startCase(place)},{' '}
-          <br className="xs-hide" />
           {since}–{until}
         </h2>
         {chart}

--- a/src/components/XAxis.js
+++ b/src/components/XAxis.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
 const XAxis = ({
+  active,
   tickCt = 8,
   tickSizeOuter = 6,
   height,
@@ -26,9 +27,13 @@ const XAxis = ({
     }
 
     return (
-      <g key={i} transform={`translate(${pos}, 0)`} className="tick">
+      <g
+        key={i}
+        transform={`translate(${pos}, 0)`}
+        className={`tick ${String(v) === String(active) ? 'bold' : ''}`}
+      >
         <line stroke="#000" y2="6" />
-        <text fill="#000" x="0" y="9" dy=".71em">{format(v)}</text>
+        <text fill="#000" x="0" y="12" dy=".71em">{format(v)}</text>
       </g>
     )
   })

--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -20,8 +20,8 @@ const YAxis = ({ tickCt = 4, scale, width }) => {
 
     return (
       <g key={i} transform={`translate(0, ${pos})`} className="tick">
-        <line x2={width} y2="0" />
-        <text fill="#000" x="-9" y="0" dy=".32em">{fmt(v)}</text>
+        <line x2={width} y2="0" strokeOpacity={i === 0 ? '1' : '.25'} />
+        <text fill="#000" x="-32" y="0" dy=".32em">{fmt(v)}</text>
       </g>
     )
   })

--- a/src/util/years.js
+++ b/src/util/years.js
@@ -1,0 +1,5 @@
+import range from 'lodash.range'
+
+export const MIN_YEAR = 1995
+export const MAX_YEAR = 2014
+export const YEAR_RANGE = range(MIN_YEAR, MAX_YEAR + 1)


### PR DESCRIPTION
cc: https://github.com/18F/crime-data-explorer/issues/44

this should have everything (sans the dropdown); i also would like to refactor the trend details table soon now that it's getting more complex. (as another issue)

preview:
<img width="751" alt="screen shot 2017-05-08 at 4 21 04 pm" src="https://cloud.githubusercontent.com/assets/1060893/25823733/f6d49cca-340a-11e7-81e3-029de6175ea4.png">
