### PR TITLE
Display arson data

### DIFF
--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -7,7 +7,7 @@ import Term from './Term'
 import mapCrimeToGlossaryTerm from '../util/glossary'
 import { nationalKey } from '../util/usa'
 
-const formatRate = n => format(`,.${+n > 250 ? 0 : 1}f`)(n)
+const formatRate = n => format(`,.${+n > 500 ? 0 : 1}f`)(n)
 const formatTotal = format(',.0f')
 
 const highlight = v => <span className="bold blue">{v}</span>

--- a/test/util/api.test.js
+++ b/test/util/api.test.js
@@ -75,7 +75,7 @@ describe('api utility', () => {
   describe('fetching summary data', () => {
     it('should request /estimates/national for national', done => {
       const spy = sandbox.stub(http, 'get', () => createPromise(success))
-      api.fetchNationalEstimates({ place: nationalKey }).then(() => {
+      api.fetchAggregates().then(() => {
         const url = spy.args[0].pop()
         expect(url.includes('/estimates/national')).toEqual(true)
         done()
@@ -84,7 +84,7 @@ describe('api utility', () => {
 
     it('should request /estimates/states/:state if place is a state', done => {
       const spy = sandbox.stub(http, 'get', () => createPromise(success))
-      api.fetchStateEstimates('california').then(() => {
+      api.fetchAggregates('california').then(() => {
         const url = spy.args[0].pop()
         expect(url.includes('/estimates/states/CA')).toEqual(true)
         done()
@@ -103,8 +103,8 @@ describe('api utility', () => {
 
     it('should return a data structure with key and results', done => {
       sandbox.stub(http, 'get', () => createPromise(success))
-      api.fetchStateEstimates('CA').then(data => {
-        expect(data.key).toEqual('CA')
+      api.fetchAggregates('california').then(data => {
+        expect(data.key).toEqual('california')
         expect(data.results).toEqual(success.results)
         done()
       })


### PR DESCRIPTION
Fetch arson data from the API (which is not estimated) and display in the trend chart using the population from the estimates endpoint.

Should close https://github.com/18F/crime-data-explorer/issues/110