### PR TITLE
add labels to trend chart

### DIFF
--- a/src/components/TrendChart.js
+++ b/src/components/TrendChart.js
@@ -101,8 +101,6 @@ class TrendChart extends React.Component {
       return { id: k.slug, name: k.name, ends, segments, values }
     })
 
-    labels.sort((a, b) => b.value.rate - a.value.rate)
-
     const gapRanges = gaps.map(year =>
       [max([year - 1, since]), year, min([year + 1, until])].map(y => parse(y)),
     )
@@ -238,19 +236,21 @@ class TrendChart extends React.Component {
                   ))}
                 </g>
               ))}
-              {labels.map((d, i) => (
-                <text
-                  dy="0.35em"
-                  key={d.name}
-                  className="fs-10 bold xs-hide"
-                  textAnchor="start"
-                  transform={`translate(${x(d.date)}, ${y(d.value.rate)})`}
-                  x="4"
-                  y={18 * (i === 0 ? -1 : 1)}
-                >
-                  {d.name}
-                </text>
-              ))}
+              {labels
+                .sort((a, b) => b.value.rate - a.value.rate)
+                .map((d, i) => (
+                  <text
+                    dy="0.35em"
+                    key={d.name}
+                    className="fs-10 bold xs-hide"
+                    textAnchor="start"
+                    transform={`translate(${x(d.date)}, ${y(d.value.rate)})`}
+                    x="4"
+                    y={18 * (i === 0 ? -1 : 1)}
+                  >
+                    {d.name}
+                  </text>
+                ))}
               {until >= 2013 &&
                 crime === 'rape' &&
                 <g

--- a/src/components/TrendChart.js
+++ b/src/components/TrendChart.js
@@ -2,9 +2,8 @@
 
 import { bisector, extent, max, min } from 'd3-array'
 import { scaleLinear, scaleOrdinal, scaleTime } from 'd3-scale'
-import { line } from 'd3-shape'
+import { curveCardinal, line } from 'd3-shape'
 import { timeParse } from 'd3-time-format'
-import startCase from 'lodash.startcase'
 import throttle from 'lodash.throttle'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -78,15 +77,17 @@ class TrendChart extends React.Component {
       ),
     )
 
-    const gaps = []
+    const [gaps, labels] = [[], []]
     const dataByKey = keysWithSlugs.map(k => {
-      const segments = [[]]
       const values = dataClean.map(d => ({
         year: d.year,
         date: d.date,
         value: d[k.slug],
       }))
       const ends = [values[0], values[values.length - 1]]
+      const segments = [[]]
+
+      labels.push({ name: k.name, ...ends[1] })
 
       values.forEach(d => {
         if (d.value.count !== 0) {
@@ -100,6 +101,8 @@ class TrendChart extends React.Component {
       return { id: k.slug, name: k.name, ends, segments, values }
     })
 
+    labels.sort((a, b) => b.value.rate - a.value.rate)
+
     const gapRanges = gaps.map(year =>
       [max([year - 1, since]), year, min([year + 1, until])].map(y => parse(y)),
     )
@@ -111,15 +114,18 @@ class TrendChart extends React.Component {
     const svgHeight = svgWidth / 2.25
     const width = svgWidth - margin.left - margin.right
     const height = svgHeight - margin.top - margin.bottom
-    const xPadding = svgWidth < 500 ? 20 : 40
+    const xPadding = svgWidth < 500 ? 30 : 80
 
     const x = scaleTime()
       .domain(extent(dataClean, d => d.date))
-      .range([0 + xPadding, width - xPadding])
+      .range([30, width - xPadding])
 
     const y = scaleLinear().domain([0, maxValue]).range([height, 0]).nice()
 
-    const l = line().x(d => x(d.date)).y(d => y(d.value.rate))
+    const l = line()
+      .curve(curveCardinal)
+      .x(d => x(d.date))
+      .y(d => y(d.value.rate))
 
     let active = yearSelected
       ? dataClean.find(d => d.year === yearSelected)
@@ -227,10 +233,23 @@ class TrendChart extends React.Component {
                       cx={x(datum.date)}
                       cy={y(datum.value.rate)}
                       fill={color(d.id)}
-                      r="3"
+                      r="3.5"
                     />
                   ))}
                 </g>
+              ))}
+              {labels.map((d, i) => (
+                <text
+                  dy="0.35em"
+                  key={d.name}
+                  className="fs-10 bold xs-hide"
+                  textAnchor="start"
+                  transform={`translate(${x(d.date)}, ${y(d.value.rate)})`}
+                  x="4"
+                  y={18 * (i === 0 ? -1 : 1)}
+                >
+                  {d.name}
+                </text>
               ))}
               {until >= 2013 &&
                 crime === 'rape' &&
@@ -248,16 +267,16 @@ class TrendChart extends React.Component {
                   <text
                     className="fill-blue fs-10 italic serif"
                     textAnchor="end"
-                    x="-4"
-                    y="-22"
+                    x="-12"
+                    y="-26"
                   >
                     Revised rape
                   </text>
                   <text
                     className="fill-blue fs-10 italic serif"
                     textAnchor="end"
-                    x="-4"
-                    y="-10"
+                    x="-12"
+                    y="-14"
                   >
                     definition
                   </text>

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -7,7 +7,7 @@ import Term from './Term'
 import mapCrimeToGlossaryTerm from '../util/glossary'
 import { nationalKey } from '../util/usa'
 
-const formatRate = n => format(`,.${+n > 500 ? 0 : 1}f`)(n)
+const formatRate = format(',.1f')
 const formatTotal = format(',.0f')
 
 const highlight = v => <span className="bold blue">{v}</span>
@@ -16,16 +16,10 @@ const getComparison = ({ place, data }) => {
   const placeRate = data[place].rate
   const nationalRate = data[nationalKey].rate
   const diff = (placeRate / nationalRate - 1) * 100
-  const diffAbs = Math.abs(diff)
 
-  return diffAbs < threshold
-    ? <span>{highlight(`about the same (within ${threshold}%)`)} as</span>
-    : <span>
-        {highlight(
-          `${formatRate(diffAbs)}% ${diff > threshold ? 'higher' : 'lower'}`,
-        )}
-        {' '}than
-      </span>
+  return Math.abs(diff) < threshold
+    ? <span>the same as</span>
+    : <span>{highlight(`${diff > 0 ? 'higher' : 'lower'}`)} than</span>
 }
 
 const TrendChartDetails = ({
@@ -69,8 +63,8 @@ const TrendChartDetails = ({
           {!isOnlyNational &&
             <span>
               In {highlight(year)}, {name}’s {term} rate was{' '}
-              {highlight(formatRate(rate))} incidents per 100,000 people,
-              which was {comparison} that of the United States.
+              {highlight(formatRate(rate))} incidents per 100,000 people.
+              The rate for that year was {comparison} that of the United States.
             </span>}
         </p>
       </div>

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -18,7 +18,7 @@ const getComparison = ({ place, data }) => {
   const diff = (placeRate / nationalRate - 1) * 100
 
   return Math.abs(diff) < threshold
-    ? <span>the same as</span>
+    ? <span>about the same (within {threshold}%) as</span>
     : <span>{highlight(`${diff > 0 ? 'higher' : 'lower'}`)} than</span>
 }
 


### PR DESCRIPTION
i tried to left align the label text above/below the last point (per mockup) but the text didn't fit within the SVG bounding box, hence this centered-aligned approach

the label is always above the line that is bigger (as of the last year) and below the line that is smaller (per mockup)

preview:
![image](https://cloud.githubusercontent.com/assets/1060893/25972284/625db738-366d-11e7-8f5b-68b2b871a62b.png)

![image](https://cloud.githubusercontent.com/assets/1060893/25972292/663be136-366d-11e7-8e32-0ecae9b2430b.png)

cc: @AvivaOskow @amberwreed 

closes https://github.com/18F/crime-data-frontend/issues/281