### PR TITLE
Connect *Container components to redux

### DIFF
--- a/src/components/AgencyChartContainer.js
+++ b/src/components/AgencyChartContainer.js
@@ -1,5 +1,6 @@
 import uniqBy from 'lodash.uniqby'
 import React from 'react'
+import { connect } from 'react-redux'
 
 import AgencyChart from './AgencyChart'
 import Loading from './Loading'
@@ -15,9 +16,8 @@ const getContent = ({ place, summary }) => {
   return <AgencyChart data={dataClean} />
 }
 
-const AgencyChartContainer = props => {
-  const { crime, place } = props
-  const content = getContent(props)
+const AgencyChartContainer = ({ crime, place, summary }) => {
+  const content = getContent({ place, summary })
 
   return (
     <div>
@@ -31,4 +31,13 @@ const AgencyChartContainer = props => {
   )
 }
 
-export default AgencyChartContainer
+const mapStateToProps = ({ filters, summaries }) => ({
+  crime: filters.crime,
+  place: filters.place,
+  summary: summaries,
+})
+const mapDispatchToProps = dispatch => ({ dispatch })
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  AgencyChartContainer,
+)

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -5,10 +5,10 @@ import AgencyChartContainer from './AgencyChartContainer'
 import ExplorerHeader from './ExplorerHeader'
 import NibrsContainer from './NibrsContainer'
 import NotFound from './NotFound'
-import Sidebar from './Sidebar'
+import SidebarContainer from './SidebarContainer'
 import SparklineSection from './SparklineSection'
 import TrendContainer from './TrendContainer'
-import UcrParticipationInformation from './UcrParticipationInformation'
+import UcrParticipationContainer from './UcrParticipationContainer'
 import { updateApp } from '../actions/composite'
 import { showTerm } from '../actions/glossary'
 import { hideSidebar, showSidebar } from '../actions/sidebar'
@@ -22,13 +22,6 @@ const getPlaceInfo = ({ place, placeType }) => ({
 })
 
 class Explorer extends React.Component {
-  constructor(props) {
-    super(props)
-    this.props = props
-    this.handleSidebarChange = ::this.handleSidebarChange
-    this.toggleSidebar = ::this.toggleSidebar
-  }
-
   componentDidMount() {
     const { appState, dispatch, router } = this.props
     const { since, until } = appState.filters
@@ -51,12 +44,12 @@ class Explorer extends React.Component {
     dispatch(updateApp(filters))
   }
 
-  handleSidebarChange(change) {
+  handleSidebarChange = change => {
     const { router } = this.props
     this.props.dispatch(updateApp(change, router))
   }
 
-  toggleSidebar() {
+  toggleSidebar = () => {
     const { dispatch } = this.props
     const { isOpen } = this.props.appState.sidebar
 
@@ -74,8 +67,7 @@ class Explorer extends React.Component {
       return <NotFound />
     }
 
-    const { agencies, filters, nibrs, sidebar, summaries, ucr } = appState
-    const { since, until } = filters
+    const { agencies, filters, summaries } = appState
     const noNibrs = ['violent-crime', 'property-crime']
     const participation = ucrParticipation(place)
     const showNibrs = !noNibrs.includes(crime) && participation.nibrs
@@ -99,13 +91,7 @@ class Explorer extends React.Component {
             </button>
           </div>
         </div>
-        <Sidebar
-          dispatch={dispatch}
-          filters={filters}
-          isOpen={sidebar.isOpen}
-          onChange={this.handleSidebarChange}
-          router={router}
-        />
+        <SidebarContainer onChange={this.handleSidebarChange} router={router} />
         <div className="site-content">
           <div className="container-main mx-auto px2 md-py3 lg-px8">
             <ExplorerHeader
@@ -114,48 +100,18 @@ class Explorer extends React.Component {
               place={place}
               placeType={placeType}
             />
-            <UcrParticipationInformation
-              dispatch={dispatch}
-              place={place}
-              placeType={placeType}
-              until={until}
-              ucr={ucr}
-            />
+            <UcrParticipationContainer />
             <hr className="mt0 mb3" />
             {isAgency &&
               <SparklineSection
                 crime={crime}
                 place={place}
-                since={since}
+                since={filters.since}
                 summaries={summaries}
-                until={until}
+                until={filters.until}
               />}
-            {isAgency
-              ? <AgencyChartContainer
-                  crime={crime}
-                  place={place}
-                  since={since}
-                  summary={summaries}
-                  until={until}
-                />
-              : <TrendContainer
-                  crime={crime}
-                  dispatch={dispatch}
-                  place={place}
-                  placeType={placeType}
-                  since={since}
-                  summaries={summaries}
-                  until={until}
-                />}
-            {showNibrs &&
-              <NibrsContainer
-                crime={params.crime}
-                dispatch={dispatch}
-                nibrs={nibrs}
-                place={place}
-                since={since}
-                until={until}
-              />}
+            {isAgency ? <AgencyChartContainer /> : <TrendContainer />}
+            {showNibrs && <NibrsContainer />}
             <hr className="mt0 mb3" />
             <AboutTheData
               crime={crime}

--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -2,6 +2,7 @@ import { format } from 'd3-format'
 import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { connect } from 'react-redux'
 
 import ErrorCard from './ErrorCard'
 import Loading from './Loading'
@@ -150,4 +151,13 @@ NibrsContainer.propTypes = {
   until: PropTypes.number.isRequired,
 }
 
-export default NibrsContainer
+const mapStateToProps = state => {
+  const { filters, nibrs } = state
+  return {
+    ...filters,
+    nibrs,
+  }
+}
+const mapDispatchToProps = dispatch => ({ dispatch })
+
+export default connect(mapStateToProps, mapDispatchToProps)(NibrsContainer)

--- a/src/components/SidebarContainer.js
+++ b/src/components/SidebarContainer.js
@@ -1,13 +1,14 @@
 import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { connect } from 'react-redux'
 
 import CrimeTypeFilter from './CrimeTypeFilter'
 import LocationFilter from './LocationFilter'
 import TimePeriodFilter from './TimePeriodFilter'
 import { hideSidebar } from '../actions/sidebar'
 
-const Sidebar = ({ dispatch, filters, isOpen, onChange }) => {
+const SidebarContainer = ({ dispatch, filters, isOpen, onChange }) => {
   const { crime, place } = filters
   const hide = () => dispatch(hideSidebar())
 
@@ -38,8 +39,14 @@ const Sidebar = ({ dispatch, filters, isOpen, onChange }) => {
   )
 }
 
-Sidebar.propTypes = {
+SidebarContainer.propTypes = {
   onChange: PropTypes.func,
 }
 
-export default Sidebar
+const mapStateToProps = ({ filters, sidebar }) => ({
+  filters,
+  isOpen: sidebar.isOpen,
+})
+const mapDispatchToProps = dispatch => ({ dispatch })
+
+export default connect(mapStateToProps, mapDispatchToProps)(SidebarContainer)

--- a/src/components/TrendContainer.js
+++ b/src/components/TrendContainer.js
@@ -3,6 +3,7 @@ import startCase from 'lodash.startcase'
 import pluralize from 'pluralize'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { connect } from 'react-redux'
 
 import DownloadDataBtn from './DownloadDataBtn'
 import Loading from './Loading'
@@ -102,4 +103,13 @@ TrendContainer.propTypes = {
   until: PropTypes.number.isRequired,
 }
 
-export default TrendContainer
+const mapStateToProps = state => {
+  const { filters, summaries } = state
+  return {
+    ...filters,
+    summaries,
+  }
+}
+const mapDispatchToProps = dispatch => ({ dispatch })
+
+export default connect(mapStateToProps, mapDispatchToProps)(TrendContainer)

--- a/src/components/UcrParticipationContainer.js
+++ b/src/components/UcrParticipationContainer.js
@@ -2,6 +2,7 @@ import { format } from 'd3-format'
 import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { connect } from 'react-redux'
 
 import Loading from './Loading'
 import PlaceThumbnail from './PlaceThumbnail'
@@ -39,7 +40,7 @@ const locationLinks = (place, type) => {
   return links.filter(l => l.text)
 }
 
-const UcrParticipationInformation = ({ place, placeType, until, ucr }) => {
+const UcrParticipationContainer = ({ place, placeType, until, ucr }) => {
   const csvLinks = participationCsvLink(place, placeType)
   const links = locationLinks(place, placeType).concat(csvLinks)
   const participation = ucrParticipation(place)
@@ -97,7 +98,7 @@ const UcrParticipationInformation = ({ place, placeType, until, ucr }) => {
   )
 }
 
-UcrParticipationInformation.propTypes = {
+UcrParticipationContainer.propTypes = {
   place: PropTypes.string.isRequired,
   placeType: PropTypes.string.isRequired,
   until: PropTypes.number.isRequired,
@@ -107,4 +108,15 @@ UcrParticipationInformation.propTypes = {
   }).isRequired,
 }
 
-export default UcrParticipationInformation
+const mapStateToProps = state => {
+  const { filters, ucr } = state
+  const { place, placeType, until } = filters
+  return {
+    place,
+    placeType,
+    ucr,
+    until,
+  }
+}
+
+export default connect(mapStateToProps)(UcrParticipationContainer)


### PR DESCRIPTION
Using the `connect()` helper to simplify what is required inside of <Explorer /> and establishes a pattern for components that get a lot of data out of the application state.

Right now, all the container components are in the same directory as the rest of the more presentational components but they're all connected to get props directly from the store.