### PR TITLE
Connect <Term /> so dispatch isn't required as a prop

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -77,22 +77,22 @@ const About = ({ dispatch }) => (
             <h3 className="mt-tiny mb2 fs-18 sm-fs-22">Available datasets</h3>
             <ul className="m0 p0 fs-14 sm-fs-16 left-bars">
               <li className="mb2">
-                <Term dispatch={dispatch} id="Summary Statistics (SRS)">
+                <Term id="Summary Statistics (SRS)">
                   Summary Statistics (SRS)
                 </Term>
               </li>
               <li className="mb2">
-                <Term dispatch={dispatch} id="Incident-based data">
+                <Term id="Incident-based data">
                   Incident-based data
                 </Term>
               </li>
               <li className="mb2">
-                <Term dispatch={dispatch} id="LEOKA">
+                <Term id="LEOKA">
                   Law Enforcement Officers Assaulted and Killed data
                 </Term>
               </li>
               <li className="mb2">
-                <Term dispatch={dispatch} id="Hate Crime">
+                <Term id="Hate Crime">
                   Hate Crime
                 </Term>
               </li>

--- a/src/components/DownloadBulkNibrs.js
+++ b/src/components/DownloadBulkNibrs.js
@@ -109,13 +109,9 @@ class DownloadBulkNibrs extends React.Component {
   }
 
   render() {
-    const { dispatch } = this.props
     const isBtnDisabled = !(this.state.place && this.state.year)
     const nibrsTerm = (
-      <Term
-        dispatch={dispatch}
-        id="national incident-based reporting system (nibrs)"
-      >
+      <Term id="national incident-based reporting system (nibrs)">
         incident-based (NIBRS)
       </Term>
     )

--- a/src/components/DownloadsAndDocs.js
+++ b/src/components/DownloadsAndDocs.js
@@ -7,13 +7,13 @@ import otherDatasets from '../../content/datasets.yml'
 
 const border = 'border-bottom border-blue-lighter'
 
-const DownloadsAndDocs = ({ dispatch }) => (
+const DownloadsAndDocs = () => (
   <section className="bg-white">
     <div className="px2 py3 container mx-auto">
       <h1 className={`mt4 mb5 pb1 sm-mt4 fs-28 sm-fs-40 ${border}`}>
         Downloads & Documentation
       </h1>
-      <DownloadBulkNibrs dispatch={dispatch} />
+      <DownloadBulkNibrs />
       <div className="mb8">
         <h2 className={`mt0 mb5 pb1 fs-22 sm-fs-32 ${border}`}>
           Bulk downloads
@@ -51,16 +51,10 @@ const DownloadsAndDocs = ({ dispatch }) => (
                 Crime data API
               </h3>
               <p>
-                Use our <Term
-                  dispatch={dispatch}
-                  id="application programming interface (api)"
-                >
+                Use our <Term id="application programming interface (api)">
                   application programming interface (API)
                 </Term> to search and export the
-                FBI’s <Term
-                  dispatch={dispatch}
-                  id="uniform crime reporting (ucr) program"
-                >
+                FBI’s <Term id="uniform crime reporting (ucr) program">
                   Uniform Crime Reporting (UCR) Program
                 </Term> data.
               </p>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -45,10 +45,7 @@ const Home = ({ appState, dispatch, router }) => {
           </h1>
           <p className="mb1 md-col-10 fs-18 sm-fs-24 serif">
             The FBI collects and publishes{' '}
-            <Term
-              dispatch={dispatch}
-              id="uniform crime reporting (ucr) program"
-            >
+            <Term id="uniform crime reporting (ucr) program">
               Uniform Crime Reporting (UCR)
             </Term> data on an annual basis.
           </p>
@@ -166,10 +163,7 @@ const Home = ({ appState, dispatch, router }) => {
           </h3>
           <p className="mb3 sm-mb6 md-col-10 fs-18 sm-fs-24 serif">
             We recently released the FBI’s first crime data{' '}
-            <Term
-              dispatch={dispatch}
-              id="application programming interface (api)"
-            >
+            <Term id="application programming interface (api)">
               application programming interface (API)
             </Term>
             {' '}

--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -34,14 +34,11 @@ const filterNibrsData = (data, { since, until }) => {
   return filtered
 }
 
-const NibrsContainer = ({ crime, dispatch, nibrs, place, since, until }) => {
+const NibrsContainer = ({ crime, nibrs, place, since, until }) => {
   const { data, error, loading } = nibrs
 
   const nibrsTerm = (
-    <Term
-      id="national incident-based reporting system (NIBRS)"
-      dispatch={dispatch}
-    >
+    <Term id="national incident-based reporting system (NIBRS)">
       incident-based (NIBRS)
     </Term>
   )
@@ -124,7 +121,6 @@ const NibrsContainer = ({ crime, dispatch, nibrs, place, since, until }) => {
 
 NibrsContainer.propTypes = {
   crime: PropTypes.string.isRequired,
-  dispatch: PropTypes.func.isRequired,
   nibrs: PropTypes.shape({
     data: PropTypes.object,
     loading: PropTypes.boolean,

--- a/src/components/Term.js
+++ b/src/components/Term.js
@@ -1,6 +1,7 @@
 import lowerCase from 'lodash.lowercase'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { connect } from 'react-redux'
 
 import { showTerm } from '../actions/glossary'
 
@@ -34,4 +35,6 @@ Term.propTypes = {
   id: PropTypes.string.isRequired,
 }
 
-export default Term
+const mapDispatchToProps = dispatch => ({ dispatch })
+
+export default connect(null, mapDispatchToProps)(Term)

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -26,7 +26,6 @@ const TrendChartDetails = ({
   colors,
   crime,
   data,
-  dispatch,
   keys,
   since,
   updateYear,
@@ -44,7 +43,7 @@ const TrendChartDetails = ({
 
   const isOnlyNational = keys.length === 1
   const term = (
-    <Term dispatch={dispatch} id={mapCrimeToGlossaryTerm(crime)}>
+    <Term id={mapCrimeToGlossaryTerm(crime)}>
       {lowerCase(crime)}
     </Term>
   )

--- a/src/components/TrendSourceText.js
+++ b/src/components/TrendSourceText.js
@@ -4,10 +4,10 @@ import React from 'react'
 
 import Term from './Term'
 
-const TrendSourceText = ({ dispatch, place, since, until }) => {
+const TrendSourceText = ({ place, since, until }) => {
   const estimated = (
     <span>
-      <Term id="estimated data" dispatch={dispatch}>
+      <Term id="estimated data">
         estimated
       </Term>
     </span>
@@ -23,7 +23,6 @@ const TrendSourceText = ({ dispatch, place, since, until }) => {
 }
 
 TrendSourceText.propTypes = {
-  dispatch: PropTypes.func,
   place: PropTypes.string,
   since: PropTypes.number.isRequired,
   until: PropTypes.number.isRequired,

--- a/src/components/UcrParticipationInformation.js
+++ b/src/components/UcrParticipationInformation.js
@@ -39,13 +39,7 @@ const locationLinks = (place, type) => {
   return links.filter(l => l.text)
 }
 
-const UcrParticipationInformation = ({
-  dispatch,
-  place,
-  placeType,
-  until,
-  ucr,
-}) => {
+const UcrParticipationInformation = ({ place, placeType, until, ucr }) => {
   const csvLinks = participationCsvLink(place, placeType)
   const links = locationLinks(place, placeType).concat(csvLinks)
   const participation = ucrParticipation(place)
@@ -57,15 +51,12 @@ const UcrParticipationInformation = ({
     <span>
       {hybrid && 'both '}
       {participation.srs &&
-        <Term dispatch={dispatch} id={'summary reporting system (srs)'}>
+        <Term id={'summary reporting system (srs)'}>
           summary (SRS)
         </Term>}
       {hybrid && ' and '}
       {participation.nibrs &&
-        <Term
-          dispatch={dispatch}
-          id={'national incident-based reporting system (nibrs)'}
-        >
+        <Term id={'national incident-based reporting system (nibrs)'}>
           incident-based (NIBRS)
         </Term>}
     </span>
@@ -108,7 +99,6 @@ const UcrParticipationInformation = ({
 }
 
 UcrParticipationInformation.propTypes = {
-  dispatch: PropTypes.func.isRequired,
   place: PropTypes.string.isRequired,
   placeType: PropTypes.string.isRequired,
   until: PropTypes.number.isRequired,


### PR DESCRIPTION
Sometimes we were passing dispatch through a few layers just to get to
a <Term /> component. Instead, the component can be connected to the
redux store so that it is always passed a copy of the store's dispatch
function.