### PR TITLE
Fix IE downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "d3-time-format": "^2.0.3",
     "element-closest": "^2.0.2",
     "express": "^4.14.0",
+    "file-saver": "^1.3.3",
     "glossary-panel": "^0.2.0",
     "js-yaml": "^3.7.0",
     "jszip": "^3.1.3",

--- a/src/components/DownloadBulkNibrs.js
+++ b/src/components/DownloadBulkNibrs.js
@@ -64,8 +64,12 @@ const createBulkNibrsUrl = (year, state) => {
 
 const downloadBulkNibrs = (year, state) => {
   const a = document.createElement('a')
+  const body = document.querySelector('body')
   a.href = createBulkNibrsUrl(year, state)
+
+  body.appendChild(a)
   a.click()
+  body.removeChild(a)
 }
 
 class DownloadBulkNibrs extends React.Component {

--- a/src/components/DownloadDataBtn.js
+++ b/src/components/DownloadDataBtn.js
@@ -1,24 +1,10 @@
+import FileSaver from 'file-saver'
 import lowerCase from 'lodash.lowercase'
 import PropTypes from 'prop-types'
 import React from 'react'
 import Zip from 'jszip'
 
 import jsonToCsv from '../util/csv'
-
-const triggerDataDownload = ({ content, filename, type }) => {
-  if (window.navigator.msSaveBlob) {
-    const blob = new Blob([content], { type })
-    window.navigator.msSaveBlob(blob, filename)
-  } else {
-    const a = document.createElement('a')
-    const body = document.querySelector('body')
-    a.download = filename
-    a.href = `data:${type},${encodeURIComponent(content)}`
-    body.appendChild(a)
-    a.click()
-    body.removeChild(a)
-  }
-}
 
 const triggerUrlDownload = url => {
   const a = document.createElement('a')
@@ -47,17 +33,13 @@ const DownloadDataBtn = ({ data, filename, text }) => {
     })
 
     return zip
-      .generateAsync({ type: 'base64' })
+      .generateAsync({ type: 'blob' })
       .then(content => {
-        triggerDataDownload({
-          content,
-          filename: `${dirname}.zip`,
-          type: 'application/zip;base64',
-        })
+        FileSaver.saveAs(content, `${dirname}.zip`)
       })
       .catch(e => {
         /* eslint-disable */
-        console.error('error from b64 zip', {
+        console.error('error from zip generation', {
           err: e,
           args: { data, filename, text },
         })

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -3,7 +3,6 @@ export default `
   !function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),
   ga("create","UA-48605964-47","auto"),
 
-  ga("require", "outboundLinkTracker"),
   ga("require", "urlChangeTracker"),
 
   ga("set","anonymizeIp",!0),


### PR DESCRIPTION
The outboundLinkTracker plugin for Google analytics seems to be causing
a bug with downloading files in IE.

Closes https://github.com/18F/crime-data-explorer/issues/131 by removing that tracker.