### PR TITLE
Map default place related filters to NibrsContainer

### DIFF
--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -7,9 +7,10 @@ import { connect } from 'react-redux'
 import ErrorCard from './ErrorCard'
 import Loading from './Loading'
 import NibrsCard from './NibrsCard'
+import Term from './Term'
 import parseNibrs from '../util/nibrs'
 import { oriToState } from '../util/ori'
-import Term from './Term'
+import { getPlaceInfo } from '../util/place'
 import ucrParticipation from '../util/ucr'
 
 const fbiLink = 'https://ucr.fbi.gov/ucr-program-data-collections'
@@ -123,6 +124,10 @@ NibrsContainer.propTypes = {
   until: PropTypes.number.isRequired,
 }
 
-const mapStateToProps = ({ filters, nibrs }) => ({ ...filters, nibrs })
+const mapStateToProps = ({ filters, nibrs }) => ({
+  ...filters,
+  ...getPlaceInfo(filters),
+  nibrs,
+})
 
 export default connect(mapStateToProps)(NibrsContainer)


### PR DESCRIPTION
Crimes that have NIBRS dimensions were failing to load for the national
perspective. The reason is because we abstracted away the default place
and placeType values into the place util but didn't use in the NIBRS
container