### PR TITLE
Fix sparklines for rape views

### DIFF
--- a/src/components/SparklineContainer.js
+++ b/src/components/SparklineContainer.js
@@ -12,10 +12,11 @@ import { nationalKey } from '../util/usa'
 
 const SparklineContainer = ({ crime, since, summaries, until, usState }) => {
   const { data, loading } = summaries
+  const normalizedCrime = crime === 'rape' ? 'rape_legacy' : crime
 
   const filterYears = d => d.year >= since && d.year <= until
   const computeRate = d => ({
-    rate: d[snakeCase(crime)] * 10000 / d.population,
+    rate: d[snakeCase(normalizedCrime)] * 10000 / d.population,
     year: d.year,
   })
 


### PR DESCRIPTION
We have two different definitions of rape, so I'm using "rape_legacy" here to draw the sparklines. This begs another question @AvivaOskow and @LarryBafundo: what should the sparklines look like for rape given the fact that we have two definitions?

Closes https://github.com/18F/crime-data-explorer/issues/168