### PR TITLE
trying to fix the space issue in state overview text

### DIFF
--- a/src/components/ExplorerUsStateIntroduction.js
+++ b/src/components/ExplorerUsStateIntroduction.js
@@ -52,7 +52,7 @@ const ExplorerUsStateIntroduction = ({ crime, place, ucr, until }) => {
               {until}
               , the FBI estimated crime statistics for
               {' '}
-              {startCase(place)}
+              {startCase(place)} 
               based on data voluntarily reported by
               {' '}
               {formatNumber(untilUcr.participating_agencies)}

--- a/src/components/ExplorerUsStateIntroduction.js
+++ b/src/components/ExplorerUsStateIntroduction.js
@@ -52,7 +52,8 @@ const ExplorerUsStateIntroduction = ({ crime, place, ucr, until }) => {
               {until}
               , the FBI estimated crime statistics for
               {' '}
-              {startCase(place)} 
+              {startCase(place)}
+              {' '}
               based on data voluntarily reported by
               {' '}
               {formatNumber(untilUcr.participating_agencies)}


### PR DESCRIPTION
I don’t know if this will work, but I added a space after
{startCase(place)}.
https://github.com/18F/crime-data-frontend/issues/842

Sorry for the misleading branch name. I planned to do something else
when I set out.