### PR TITLE
set higher yaxis min for agency chart

### DIFF
--- a/src/components/AgencyChart.js
+++ b/src/components/AgencyChart.js
@@ -49,7 +49,7 @@ class AgencyChart extends React.Component {
     const xPadding = svgWidth < 500 ? 20 : 40
 
     const keys = ['reported', 'cleared']
-    const yMax = max(data, d => max(keys, k => d[k]))
+    const yMax = max([3, max(data, d => max(keys, k => d[k]))])
 
     const colorMap = scaleOrdinal().domain(keys).range(colors)
     const mutedColorMap = scaleOrdinal().domain(keys).range(mutedColors)


### PR DESCRIPTION
(needs to be 3, not 4, so gridlines are on whole numbers)

refs: https://github.com/18F/crime-data-explorer/issues/166

preview:
<img width="855" alt="screen shot 2017-06-08 at 1 28 04 pm" src="https://user-images.githubusercontent.com/1060893/26941982-73fcee90-4c4e-11e7-821a-b072a7860f6a.png">
