### PR TITLE
Deploy all branches to unique apps

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,12 +19,16 @@ test:
     - npm run coverage
 
 deployment:
+  auto:
+    branch: /^((?!master).)*$/
+    commands:
+      - npm run build && node scripts/deployAndDelete.js
   master:
     branch: master
     commands:
+      - npm run build && node scripts/deployAndDelete.js
       - curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
       - sudo dpkg -i cf-cli_amd64.deb
-      - npm run build
       - cf install-plugin autopilot -f -r CF-Community
       - cf api $CF_API
       - cf auth $CF_USERNAME $CF_PASSWORD && cf target -o $CF_ORGANIZATION -s $CF_SPACE

--- a/circle.yml
+++ b/circle.yml
@@ -20,18 +20,25 @@ test:
 
 deployment:
   auto:
-    branch: /^((?!master).)*$/
+    branch: /^(?!master$).*$/
     commands:
-      - npm run build && node scripts/deployAndDelete.js
-  master:
-    branch: master
-    commands:
-      - npm run build && node scripts/deployAndDelete.js
       - curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
       - sudo dpkg -i cf-cli_amd64.deb
       - cf install-plugin autopilot -f -r CF-Community
       - cf api $CF_API
       - cf auth $CF_USERNAME $CF_PASSWORD && cf target -o $CF_ORGANIZATION -s $CF_SPACE
+      - npm run build
+      - node scripts/deployAndDelete.js
+  master:
+    branch: master
+    commands:
+      - curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+      - sudo dpkg -i cf-cli_amd64.deb
+      - cf install-plugin autopilot -f -r CF-Community
+      - cf api $CF_API
+      - cf auth $CF_USERNAME $CF_PASSWORD && cf target -o $CF_ORGANIZATION -s $CF_SPACE
+      - npm run build
+      - node scripts/deployAndDelete.js
       - cf zero-downtime-push $CF_APP -f manifests/master.yml
   release:
     tag: /v[0-9]+(\.[0-9]+)*/

--- a/scripts/deployAndDelete.js
+++ b/scripts/deployAndDelete.js
@@ -1,0 +1,112 @@
+/* eslint-disable no-console */
+
+/*
+deploy any commit to an app named like after the branch
+if the last commit is a merge commit (written with an
+assumption of a protected main/master branch), then
+delete that branch's app.
+*/
+
+const exec = require('child_process').exec
+const fs = require('fs')
+const path = require('path')
+
+const yaml = require('js-yaml')
+
+const APP_NAME_BASE = 'crime-data-explorer'
+const MANIFEST_DIR = path.join(__dirname, '../manifests')
+const MANIFEST_BASE = path.join(MANIFEST_DIR, 'master.yml')
+
+const execThen = cmd =>
+  new Promise((resolve, reject) => {
+    exec(cmd, (err, stdout, stderr) => {
+      if (err || stderr) return reject(err || stderr)
+
+      return resolve(stdout)
+    })
+  })
+
+const fsReadThen = filePath =>
+  new Promise((resolve, reject) => {
+    fs.readFile(filePath, (err, file) => {
+      if (err) return reject(err)
+
+      return resolve(file)
+    })
+  })
+
+const fsWriteThen = (filePath, contents) =>
+  new Promise((resolve, reject) => {
+    fs.writeFile(filePath, contents, err => {
+      if (err) return reject(err)
+      return resolve(filePath)
+    })
+  })
+
+const appName = branch => `${APP_NAME_BASE}-${branch}`
+
+const createNewManifest = (base, branch) => {
+  // assumes a single application in the manifest
+  const app = Object.assign({}, base.applications[0], {
+    name: appName(branch),
+    host: appName(branch),
+    disk_quota: '256M', // this is not very generic, but we have a simple app
+    memory: '256M', // samsies
+  })
+  return Object.assign({}, base, {
+    applications: [app],
+  })
+}
+
+const deployApp = branch => {
+  console.log(`deploying ${appName(branch)}`)
+  return fsReadThen(MANIFEST_BASE)
+    .then(manifest => {
+      try {
+        return yaml.safeLoad(manifest)
+      } catch (e) {
+        throw e
+      }
+    })
+    .then(manifest => {
+      console.log(`creating manifest for ${appName(branch)}`)
+      return manifest
+    })
+    .then(manifest => createNewManifest(manifest, branch))
+    .then(manifest => `---\n${yaml.safeDump(manifest)}`)
+    .then(manifest => {
+      const manifestPath = path.join(MANIFEST_DIR, `${branch}.yml`)
+      return fsWriteThen(manifestPath, manifest)
+    })
+    .then(manifestPath => {
+      const cmd = `cf push -f ${manifestPath}`
+      console.log(`pushing ${appName(branch)}`)
+      return execThen(cmd).then(() => cmd)
+    })
+}
+
+const deleteApp = branch => {
+  const cmd = `cf delete -f ${appName(branch)}`
+  console.log(`deleteing ${appName(branch)}`)
+  return execThen(cmd).then(() => cmd)
+}
+
+const getCurrentBranch = () => {
+  const cmd = 'git rev-parse --abbrev-ref HEAD'
+  return execThen(cmd).then(branch => branch.replace(/\n/g, ''))
+}
+
+execThen('git log -1')
+  .then(log => {
+    const mergeRegex = /Merge pull request #\d+ from (\w+)\/(.+)/
+    const matches = log.match(mergeRegex)
+
+    if (matches) return deleteApp(matches[2])
+
+    return getCurrentBranch().then(branch => {
+      if (branch !== 'master') return deployApp(branch)
+      return 'no command. do not run on master branch'
+    })
+  })
+  .then(cmd => console.log(`successfully ran ${cmd}`))
+  .catch(err => console.error(err))


### PR DESCRIPTION
A pain point in our workflow is getting design approval to changes. It would be awesome to have automatic apps and unique URLs created for each pull request so that we can do code reviews and design reviews without merging and closing the original issue.

This is a first attempt at doing something like that. It checks the latest commit for the pattern used by Github when pull requests are merged through the web interface, and if it is found it tries to delete the app created for that branch. If the branch isn't `master` and the last commit message doesn't have the merge pattern, then create a manifest file for the app and use it to deploy the app. It names the app `crime-data-explorer-${branch}` and binds a similar URL to the app like `https://crime-data-explorer-${branch}.fr.cloud.gov`. It also adds the command to circle and instructs the CI to run the node script.

For example, this branch was deployed to https://crime-data-explorer-jk-deploy-all-branches.fr.cloud.gov/.

Perhaps not the best way to do this since the `child_process` doesn't stream the regular standard out but more of a proof of concept. Since we'll be using the `cf` tool for every branch, perhaps we should also cache that download to cut down the individual build time.