### PR TITLE
Use API data gov proxy for -demo app

### DIFF
--- a/manifests/base.yml
+++ b/manifests/base.yml
@@ -1,5 +1,5 @@
 services:
-- crime-data-api-creds
+- crime-data-creds
 env:
   GITHUB_ISSUE_REPO_OWNER: '18f'
   GITHUB_ISSUE_REPO_NAME: 'crime-data-explorer'

--- a/manifests/demo.yml
+++ b/manifests/demo.yml
@@ -7,4 +7,6 @@ applications:
   memory: 512M
   domain: fr.cloud.gov
 env:
-  CDE_API: 'https://crime-data-api-demo.fr.cloud.gov'
+  CDE_API: 'https://api.usa.gov/crime/fbi/ucr'
+services:
+  - crime-data-api-key-production

--- a/manifests/master.yml
+++ b/manifests/master.yml
@@ -8,3 +8,5 @@ applications:
   domain: fr.cloud.gov
 env:
   CDE_API: 'https://crime-data-api.fr.cloud.gov'
+services:
+  - crime-data-api-key-development

--- a/manifests/staging.yml
+++ b/manifests/staging.yml
@@ -8,3 +8,5 @@ applications:
   domain: fr.cloud.gov
 env:
   CDE_API: 'https://crime-data-api.fr.cloud.gov'
+services:
+  - crime-data-api-key-development

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,6 @@ import 'babel-polyfill'
 import http from 'axios'
 import basicAuth from 'basic-auth-connect'
 import bodyParser from 'body-parser'
-import cfenv from 'cfenv'
 import express from 'express'
 import gzipStatic from 'connect-gzip-static'
 import path from 'path'
@@ -19,6 +18,7 @@ import renderHtml from './html'
 import routes from './routes'
 import configureStore from './store'
 import { updateFilters } from './actions/filters'
+import createEnv from './util/env'
 import { createIssue } from './util/github'
 import history from './util/history'
 
@@ -26,28 +26,23 @@ const isProd = process.env.NODE_ENV === 'production'
 
 if (isProd) require('newrelic')
 
-const env = cfenv.getAppEnv()
+const ENV = createEnv()
 
-const credService = env.getService('crime-data-api-creds') || {
-  credentials: {},
-}
-const getEnvVar = name => {
-  if (credService.credentials[name]) return credService.credentials[name]
-  if (process.env[name]) return process.env[name]
-  return false
-}
-
-const { HTTP_BASIC_USERNAME, HTTP_BASIC_PASSWORD } = credService.credentials
-const API = process.env.CDE_API
-const apiKey = getEnvVar('API_KEY')
+const {
+  CDE_API: API,
+  API_KEY: apiKey,
+  GITHUB_ISSUE_REPO_OWNER: repoOwner,
+  GITHUB_ISSUE_REPO_NAME: repoName,
+  GITHUB_ISSUE_BOT_TOKEN: repoToken,
+  HTTP_BASIC_USERNAME,
+  HTTP_BASIC_PASSWORD,
+  PORT,
+} = ENV
 const initState = {
   agency: { loading: true },
   ucr: { loading: true, data: {} },
   summaries: { loading: true, data: {} },
 }
-const repoOwner = getEnvVar('GITHUB_ISSUE_REPO_OWNER')
-const repoName = getEnvVar('GITHUB_ISSUE_REPO_NAME')
-const repoToken = getEnvVar('GITHUB_ISSUE_BOT_TOKEN')
 
 const acceptHostname = hostname => {
   if (!isProd) return true
@@ -127,6 +122,6 @@ app.get('/*', (req, res) => {
   })
 })
 
-app.listen(env.port, () => {
-  console.log(`Listening on ${env.port}`)
+app.listen(PORT, () => {
+  console.log(`Listening on ${PORT}`)
 })

--- a/src/util/env.js
+++ b/src/util/env.js
@@ -1,0 +1,23 @@
+import cfenv from 'cfenv'
+
+const env = cfenv.getAppEnv()
+
+const combineServiceCredentials = services =>
+  services.map(service => service.credentials || {}).reduce((a, n) => ({
+    ...a,
+    ...n,
+  }))
+
+const combineCfCUPSAndEnv = () => {
+  const services = Object.keys(env.getServices()).map(service =>
+    env.getService(service),
+  )
+  const combined = combineServiceCredentials(services)
+
+  return {
+    ...process.env,
+    ...combined,
+  }
+}
+
+export default combineCfCUPSAndEnv


### PR DESCRIPTION
Create a few new services in cloud.gov to store the different credentials and bind them through the manifests. Also adds a `env` util that combines all user provided services and `process.env` so that environment variables are easier to work with across local and deployed environments

Closes https://github.com/18F/crime-data-frontend/issues/401