### PR TITLE
Shrink footprint of staging and master apps

### DIFF
--- a/manifests/master.yml
+++ b/manifests/master.yml
@@ -4,7 +4,8 @@ applications:
 - name: crime-data-explorer
   host: crime-data-explorer
   buildpack: nodejs_buildpack
-  memory: 512M
+  memory: 256M
+  disk_quota: 256M
   domain: fr.cloud.gov
 env:
   CDE_API: 'https://crime-data-api.fr.cloud.gov'

--- a/manifests/staging.yml
+++ b/manifests/staging.yml
@@ -4,7 +4,8 @@ applications:
 - name: crime-data-explorer-staging
   host: crime-data-explorer-staging
   buildpack: nodejs_buildpack
-  memory: 512M
+  memory: 256M
+  disk_quota: 256M
   domain: fr.cloud.gov
 env:
   CDE_API: 'https://crime-data-api.fr.cloud.gov'


### PR DESCRIPTION
With our autodeploy feature we want to make apps as small as possible so that more than a few can be deployed. Since master and staging get very little traffic, I think its fine to shrink them down to the same size as the automatically created apps.