### PR TITLE
Include offender and victim ethnicity in NIBRS charts

### DIFF
--- a/src/util/api.js
+++ b/src/util/api.js
@@ -27,7 +27,7 @@ const getNibrs = ({ crime, dim, place, placeType, type }) => {
         ? `agencies/${place}`
         : `states/${lookupUsa(place)}`
 
-  const field = dimensionEndpoints[dim]
+  const field = dimensionEndpoints[dim] || dim
   const fieldPath = `${field}/offenses`
   const url = `${API}/${type}s/count/${loc}/${fieldPath}`
 
@@ -47,11 +47,13 @@ const getNibrsRequests = params => {
   const { crime, place, placeType } = params
 
   const slices = [
-    { type: 'offender', dim: 'sexCode' },
-    { type: 'offender', dim: 'raceCode' },
     { type: 'offender', dim: 'ageNum' },
+    { type: 'offender', dim: 'ethnicity' },
+    { type: 'offender', dim: 'raceCode' },
+    { type: 'offender', dim: 'sexCode' },
     { type: 'offense', dim: 'locationName' },
     { type: 'victim', dim: 'ageNum' },
+    { type: 'victim', dim: 'ethnicity' },
     { type: 'victim', dim: 'raceCode' },
     { type: 'victim', dim: 'sexCode' },
     { type: 'victim', dim: 'relationship' },

--- a/src/util/nibrs.js
+++ b/src/util/nibrs.js
@@ -95,7 +95,12 @@ export const binAge = data => {
 // nibrs cards
 
 const offenderDemo = data => {
-  const { offenderAgeNum, offenderRaceCode, offenderSexCode } = data
+  const {
+    offenderAgeNum,
+    offenderEthnicity,
+    offenderRaceCode,
+    offenderSexCode,
+  } = data
 
   return {
     title: 'Offender demographics',
@@ -119,12 +124,18 @@ const offenderDemo = data => {
         title: 'Race of offender',
         type: 'table',
       },
+      {
+        data: reshape(offenderEthnicity, 'ethnicity'),
+        noun: 'offender',
+        title: 'Ethnicity of offender',
+        type: 'table',
+      },
     ],
   }
 }
 
 const victimDemo = data => {
-  const { victimAgeNum, victimRaceCode, victimSexCode } = data
+  const { victimAgeNum, victimEthnicity, victimRaceCode, victimSexCode } = data
 
   return {
     title: 'Victim demographics',
@@ -146,6 +157,12 @@ const victimDemo = data => {
         data: rename(reshape(victimRaceCode, 'race_code'), raceCodes),
         noun: 'victim',
         title: 'Race of victim',
+        type: 'table',
+      },
+      {
+        data: reshape(victimEthnicity, 'ethnicity'),
+        noun: 'victim',
+        title: 'Ethnicity of victim',
         type: 'table',
       },
     ],

--- a/test/fixtures/nibrsApiResponse.json
+++ b/test/fixtures/nibrsApiResponse.json
@@ -7,6 +7,9 @@
     {"count":5,"offense_name":"homicide","race_code":"B","year":"2006"},
     {"count":2,"offense_name":"homicide","race_code":"B","year":"2008"}
   ],
+  "offenderEthnicity": [
+    {"count":1,"ethnicity":"Unknown","offense_name":"homicide","year":"1991"}
+  ],
   "offenderAgeNum":[
     {"age_num":20,"count":4,"offense_name":"homicide","year":"2006"},
     {"age_num":30,"count":1,"offense_name":"homicide","year":"2006"}
@@ -18,6 +21,9 @@
   "victimRaceCode":[
     {"count":5,"offense_name":"homicide","race_code":"B","year":"2006"},
     {"count":2,"offense_name":"homicide","race_code":"B","year":"2008"}
+  ],
+  "victimEthnicity": [
+    {"count":1,"ethnicity":"Unknown","offense_name":"homicide","year":"1991"}
   ],
   "victimAgeNum":[
     {"age_num":20,"count":4,"offense_name":"homicide","year":"2006"},

--- a/test/util/api.test.js
+++ b/test/util/api.test.js
@@ -63,10 +63,10 @@ describe('api utility', () => {
   })
 
   describe('getNibrsRequests()', () => {
-    it('should call getNibrs 8 times', done => {
+    it('should call getNibrs 10 times', done => {
       const spy = sandbox.stub(http, 'get', () => createPromise(success))
       Promise.all(api.getNibrsRequests(params)).then(() => {
-        expect(spy.callCount).toEqual(8)
+        expect(spy.callCount).toEqual(10)
         done()
       })
     })


### PR DESCRIPTION
Closes https://github.com/18F/crime-data-explorer/issues/2

The offenders API is returning `null` counts, so the chart looks weird but I opened https://github.com/18F/crime-data-api/issues/562 for that.

<img width="927" alt="screen shot 2017-06-14 at 11 44 41 pm" src="https://user-images.githubusercontent.com/780941/27164474-8a980fa6-515b-11e7-80c8-411ed3d41c80.png">
