### PR TITLE
Show agency name instead of ORI in NIBRS container introduction text

### DIFF
--- a/src/components/AgencyChartDetails.js
+++ b/src/components/AgencyChartDetails.js
@@ -1,4 +1,5 @@
 import { format } from 'd3-format'
+import lowerCase from 'lodash.lowercase'
 import range from 'lodash.range'
 import pluralize from 'pluralize'
 import PropTypes from 'prop-types'
@@ -31,7 +32,7 @@ const AgencyChartDetails = ({
           <strong>{fmt(reported)}</strong> reported and{' '}
           <strong>{fmt(cleared)}</strong> cleared{' '}
           {pluralize('incidents', isSingular ? 1 : 2)}{' '}
-          of {crime}.
+          of {lowerCase(crime)}.
         </p>
       </div>
       <div className="flex-none" style={{ width: 210 }}>

--- a/src/containers/NibrsContainer.js
+++ b/src/containers/NibrsContainer.js
@@ -105,7 +105,7 @@ const NibrsContainer = ({
         </h2>
         {nibrsFirstYear !== since &&
           <p className="my-tiny">
-            {startCase(place)} started reporting {nibrsTerm} data
+            {placeDisplay} started reporting {nibrsTerm} data
             to the FBI in {nibrsFirstYear}.
           </p>}
         {!error &&


### PR DESCRIPTION
Also, properly format crime name in agency chart details to remove the hyphen from multi-word offenses.

Refs https://github.com/18F/crime-data-explorer/issues/185

<img width="873" alt="screen shot 2017-06-15 at 3 41 32 pm" src="https://user-images.githubusercontent.com/780941/27198685-44d5365c-51e1-11e7-94f2-533261e7b87c.png">
