### PR TITLE
Add glossary icons next to relevant links in About the Data

### DIFF
--- a/sass/components/_glossary.scss
+++ b/sass/components/_glossary.scss
@@ -48,3 +48,14 @@
     margin-top: $space-tiny;
   }
 }
+
+.glossary-icon::after {
+  background-image: url('/img/glossary.svg');
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  content: '';
+  display: inline-block;
+  height: 10px;
+  padding-left: .5rem;
+  width: 10px;
+}

--- a/src/util/md.js
+++ b/src/util/md.js
@@ -10,7 +10,12 @@ const defaultLinkRender =
   ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options))
 
 markdown.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-  tokens[idx].attrPush(['class', 'underline'])
+  const token = tokens[idx]
+  const href = token.attrs.find(a => a[0] === 'href')
+  const isTerm = href[1].match(/#glossary\?term=/)
+  const gi = 'glossary-icon glossary-icon-md'
+
+  token.attrPush(['class', `underline ${isTerm && gi}`])
   return defaultLinkRender(tokens, idx, options, env, self)
 }
 


### PR DESCRIPTION
<img width="953" alt="screen shot 2017-06-15 at 4 03 33 pm" src="https://user-images.githubusercontent.com/780941/27199498-3a88870a-51e4-11e7-846b-7e2bc3e35e61.png">

Refs #723