### PR TITLE
Update About page participation map

### DIFF
--- a/sass/util/_colors.scss
+++ b/sass/util/_colors.scss
@@ -47,6 +47,7 @@
 .fill-blue-white { fill: $blue-white; }
 .fill-red { fill: $red; }
 .fill-red-bright { fill: $red-bright; }
+.fill-red-dark { fill: $red-dark; }
 .fill-red-light { fill: $red-light; }
 
 .hover-blue:hover { color: $blue; }

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -31,8 +31,8 @@ const legend = [
   },
   {
     check: stateProgram => !stateProgram,
-    css: 'fill-red-bright',
-    hex: '#ff5e50',
+    css: 'fill-red-dark',
+    hex: '#702c27',
     text: 'No state program',
   },
 ]
@@ -151,7 +151,8 @@ const About = ({ dispatch }) =>
             </div>
           </div>
           <div className="fs-12 serif italic">
-            U.S. territories are not included in the map
+            Other outlying areas include America Samoa, Guam, Puerto Rico, and
+            U.S. Virgin Islands.
           </div>
         </div>
       </div>


### PR DESCRIPTION
* Change red color of legend and MS to #702C27
* Change the "U.S. territories are not included in the map" to say
"Other outlying areas include America Samoa, Guam, Puerto Rico, and
U.S. Virgin Islands."

![screencapture-localhost-6005-about-1497920165479](https://user-images.githubusercontent.com/780941/27311922-4f2e4c52-5532-11e7-9567-9135811578b5.png)

Refs #989 https://github.com/18F/crime-data-explorer/issues/36