### PR TITLE
Update agency chart text to use proper unit

### DIFF
--- a/src/components/AgencyChart.js
+++ b/src/components/AgencyChart.js
@@ -39,7 +39,16 @@ class AgencyChart extends React.Component {
   }
 
   render() {
-    const { colors, crime, data, mutedColors, since, size, until } = this.props
+    const {
+      colors,
+      crime,
+      data,
+      mutedColors,
+      since,
+      size,
+      submitsNibrs,
+      until,
+    } = this.props
     const { hover, svgParentWidth, yearSelected } = this.state
 
     const svgWidth = svgParentWidth || size.width
@@ -54,6 +63,7 @@ class AgencyChart extends React.Component {
 
     const colorMap = scaleOrdinal().domain(keys).range(colors)
     const mutedColorMap = scaleOrdinal().domain(keys).range(mutedColors)
+    const noun = submitsNibrs ? 'incidents' : 'offenses'
 
     const y = scaleLinear().domain([0, yMax]).rangeRound([height, 0]).nice()
 
@@ -86,12 +96,13 @@ class AgencyChart extends React.Component {
           crime={crime}
           data={active}
           keys={keys}
+          noun={noun}
           since={since}
           updateYear={this.updateYear}
           until={until}
         />
         <div className="mb2 h6 bold monospace black">
-          Total incidents reported by year
+          Total {noun} reported by year
         </div>
         <div className="mb3 col-12" ref={ref => (this.svgParent = ref)}>
           <svg width={svgWidth} height={svgHeight} style={{ maxWidth: '100%' }}>
@@ -151,6 +162,7 @@ AgencyChart.propTypes = {
     width: PropTypes.number,
     margin: PropTypes.object,
   }).isRequired,
+  submitsNibrs: PropTypes.bool.isRequired,
   until: PropTypes.number.isRequired,
 }
 

--- a/src/components/AgencyChartDetails.js
+++ b/src/components/AgencyChartDetails.js
@@ -1,5 +1,6 @@
 import { format } from 'd3-format'
 import lowerCase from 'lodash.lowercase'
+import startCase from 'lodash.startcase'
 import range from 'lodash.range'
 import pluralize from 'pluralize'
 import PropTypes from 'prop-types'
@@ -63,7 +64,7 @@ const AgencyChartDetails = ({
                     className="mr1 inline-block"
                     style={{ width: 8, height: 8, backgroundColor: colors(k) }}
                   />
-                  <Term id={k} size="sm">{k}</Term>
+                  <Term id={k} size="sm">{startCase(k)}</Term>
                 </td>
                 <td className="pt1 line-height-4 align-bottom right-align">
                   <span className="inline-block border-bottom border-blue-light col-12">

--- a/src/components/AgencyChartDetails.js
+++ b/src/components/AgencyChartDetails.js
@@ -15,6 +15,7 @@ const AgencyChartDetails = ({
   crime,
   data,
   keys,
+  noun,
   since,
   until,
   updateYear,
@@ -32,8 +33,7 @@ const AgencyChartDetails = ({
           {pluralize('were', isSingular ? 1 : 2)}{' '}
           <strong>{fmt(reported)}</strong> reported and{' '}
           <strong>{fmt(cleared)}</strong> cleared{' '}
-          {pluralize('incidents', isSingular ? 1 : 2)}{' '}
-          of {lowerCase(crime)}.
+          {pluralize(noun, isSingular ? 1 : 2)} of ${lowerCase(crime)}.
         </p>
       </div>
       <div className="flex-none" style={{ width: 210 }}>
@@ -53,7 +53,7 @@ const AgencyChartDetails = ({
                   {yearRange.map((y, i) => <option key={i}>{y}</option>)}
                 </select>
               </td>
-              <th className="right-align">Incidents</th>
+              <th className="right-align">{startCase(noun)}</th>
             </tr>
           </thead>
           <tbody className="fs-14 bold">
@@ -85,6 +85,7 @@ AgencyChartDetails.propTypes = {
   crime: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
   keys: PropTypes.arrayOf(PropTypes.string).isRequired,
+  noun: PropTypes.string.isRequired,
   since: PropTypes.number.isRequired,
   until: PropTypes.number.isRequired,
   updateYear: PropTypes.func.isRequired,

--- a/src/containers/AgencyChartContainer.js
+++ b/src/containers/AgencyChartContainer.js
@@ -12,7 +12,7 @@ import NoData from '../components/NoData'
 import { nibrsTerm, srsTerm } from '../components/Terms'
 import { getAgency } from '../util/ori'
 
-const getContent = ({ crime, place, since, summary, until }) => {
+const Content = ({ crime, place, since, submitsNibrs, summary, until }) => {
   const { error, loading } = summary
 
   if (loading) return <Loading />
@@ -30,9 +30,10 @@ const getContent = ({ crime, place, since, summary, until }) => {
     dataClean.length ===
     dataClean.filter(d => d.reported === 0 && d.cleared === 0).length
 
+  const noun = submitsNibrs ? 'incidents' : 'offenses'
   const noDataText = `There were no ${lowerCase(
     crime,
-  )} incidents reported during this time period.`
+  )} ${noun} reported during this time period.`
 
   return (
     <div>
@@ -43,6 +44,7 @@ const getContent = ({ crime, place, since, summary, until }) => {
               crime={crime}
               data={dataClean}
               since={since}
+              submitsNibrs={submitsNibrs}
               until={until}
             />
             <DownloadDataBtn
@@ -60,16 +62,16 @@ const AgencyChartContainer = params => {
   if (!agency) return null
 
   const submitsNibrs = agency.nibrs_months_reported === 12
-  const content = getContent(params)
+  const noun = submitsNibrs ? 'incidents' : 'offenses'
 
   return (
     <div className="mb5">
       <div className="p2 sm-p4 bg-white border-top border-blue border-w8">
         <h2 className="mt0 mb3 fs-24 sm-fs-28 sans-serif">
-          {startCase(crime)} incidents reported by{' '}
+          {startCase(crime)} {noun} reported by{' '}
           {agency.display}, {since}-{until}
         </h2>
-        {content}
+        <Content submitsNibrs={submitsNibrs} {...params} />
       </div>
       {!summary.loading &&
         <div className="mt2 fs-12 serif italic">


### PR DESCRIPTION
Use "offenses" as a unit if the agency submits SRS data and "incidents" if it submits NIBRS data.

URLs/ORIs for reviewing:
* `/explorer/agency/NJ0110500/homicide` - SRS agency with no data during reporting period
* `/explorer/agency/CA0210400/violent-crime` - SRS agency with data during reporting period
* `/explorer/agency/AR0020100/violent-crime` - NIBRS agency with data during reporting period

Refs #949