### PR TITLE
small content fixes

### DIFF
--- a/sass/core/_color-base.scss
+++ b/sass/core/_color-base.scss
@@ -6,6 +6,7 @@ body {
 a {
   color: $link-color;
   text-decoration: $link-text-decoration;
+  text-decoration-skip: ink;
   &:hover { text-decoration: $link-hover-text-decoration; }
 }
 

--- a/src/components/ExplorerIntroAgency.js
+++ b/src/components/ExplorerIntroAgency.js
@@ -19,7 +19,7 @@ const ExplorerIntroAgency = ({
   const showCounty =
     (county && type === 'City') || type === 'University or College'
   const crimeTerm = (
-    <Term id={mapCrimeToGlossaryTerm(crime)} size="sm">
+    <Term id={mapCrimeToGlossaryTerm(crime)}>
       {upperFirst(lowerCase(crime))}
     </Term>
   )

--- a/src/components/ExplorerIntroNational.js
+++ b/src/components/ExplorerIntroNational.js
@@ -12,7 +12,7 @@ const ExplorerIntroNational = ({ crime, ucr, until }) => {
   const isArson = crime === 'arson'
   const untilUcr = ucr.find(p => p.year === until)
   const crimeTerm = (
-    <Term id={mapCrimeToGlossaryTerm(crime)} size="sm">
+    <Term id={mapCrimeToGlossaryTerm(crime)}>
       {upperFirst(lowerCase(crime))}
     </Term>
   )

--- a/src/components/Term.js
+++ b/src/components/Term.js
@@ -19,7 +19,7 @@ const Term = ({ children, dispatch, id, size = 'md' }) => {
   return (
     <a
       aria-label={`Show ${lowerCase(id)} in the glossary`}
-      className="border-bottom-dotted"
+      className="inline-block border-bottom-dotted"
       href="#!"
       onClick={handler}
     >


### PR DESCRIPTION
Refs https://github.com/18F/crime-data-frontend/issues/1031

also makes crime term glossary icon sizes consistent and improves underline display using `text-decoration-skip=ink` to match sketch designs