### PR TITLE
Fix NIBRS loading error on agencies

### DIFF
--- a/src/containers/NibrsContainer.js
+++ b/src/containers/NibrsContainer.js
@@ -59,8 +59,8 @@ const NibrsContainer = ({
   const nibrsFirstYear = initialNibrsYear({ place, placeType, since })
   const { data, error } = nibrs
 
-  const isLoading = nibrs.loading || ucr.loading
-  const isReady = !isLoading && !error && !!data
+  const isLoading = isAgency ? nibrs.loading : nibrs.loading || ucr.loading
+  const isReady = !isLoading && error === null && !!data
 
   let totalCount = 0
   let content = null


### PR DESCRIPTION
The NIBRS section for an agency had a loading bug where it would appear to load for a while. This was caused by the fact that we were using both the NIBRS data and UCR data (from their respective reducers) to determine if we should show the loading screen or not. In addition, we set both loading to true for the server side render.

This works fine for state views that do actually make UCR requests and, therefore, set the loading flag to false for that reducer. If the user then looks at an agency, that would also work fine since the flag remains flipped. However, for an agency, we do not submit any UCR data related requests to the API and so the flag would never flip. This would result in the NIBRS data being available to show but not being shown because the app continues to show the loading indicator.

@brendansudol do you have any ideas about ways we could make this cleaner/more obvious?