### PR TITLE
trend table overflow fix

### DIFF
--- a/sass/core/_base-tables.scss
+++ b/sass/core/_base-tables.scss
@@ -1,7 +1,6 @@
 table {
   border-collapse: separate;
   border-spacing: 0;
-  max-width: 100%;
   width: 100%;
 }
 

--- a/sass/util/_width.scss
+++ b/sass/util/_width.scss
@@ -1,3 +1,4 @@
 .mw8 { max-width: 8rem; }
 .mw20 { max-width: 20rem; }
 .mw30 { max-width: 30rem; }
+.mw-fill { max-width: 100%; }

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -86,12 +86,12 @@ const TrendChartDetails = ({
   return (
     <div className="mb3 sm-mb5 lg-flex">
       <div className="flex-auto">
-        <p className="mb1 lg-m0 lg-pr5 lg-mh-72p fs-14">
+        <p className="mb2 lg-m0 lg-pr5 lg-mh-72p fs-14">
           {sentence}
         </p>
       </div>
-      <div className="flex-none overflow-auto">
-        <table className="mb1 lg-m0 p2 col-12 sm-col-5 bg-blue-white rounded">
+      <div className="flex-none inline-block mw-fill overflow-auto bg-blue-white rounded">
+        <table className="p2 sm-col-5">
           <thead className="fs-10 line-height-4 right-align">
             <tr>
               <td className="left-align">


### PR DESCRIPTION
fixes: https://github.com/18F/crime-data-frontend/issues/980

preview:
![trend-table](https://user-images.githubusercontent.com/1060893/27928495-7fabdc68-625d-11e7-993e-a7f52ad809b4.gif)
