### PR TITLE
add app max width

### DIFF
--- a/sass/components/_layout.scss
+++ b/sass/components/_layout.scss
@@ -11,13 +11,13 @@
 
 $sidebar-width: 20rem;
 
-html {
-  height: 100%;
-}
+html { height: 100%; }
+body { min-height: 100%; }
 
-body,
 #app {
+  max-width: 85rem;
   min-height: 100%;
+  position: relative;
 }
 
 .site {


### PR DESCRIPTION
fixes: https://github.com/18F/crime-data-frontend/issues/1088

(sets max width of the app to 1360, so that on really big screens there's not weird spacing issues)

preview (of screen that's 2000px+ wide):
<img width="1093" alt="screen shot 2017-07-07 at 10 33 20 am" src="https://user-images.githubusercontent.com/1060893/27962626-7a6915ce-6300-11e7-83a4-fe059927e197.png">

