### PR TITLE
Do not use -p flag for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node build/server.js",
     "postinstall": "npm run swagger",
-    "build": "export NODE_ENV=production && webpack -p --progress --config webpack.config.js && unset NODE_ENV",
+    "build": "export NODE_ENV=production && webpack --progress && unset NODE_ENV",
     "watch": "webpack -w --progress --config webpack.config.js & nodemon build/server.js",
     "lint": "npm run lint:js && npm run lint:yml",
     "lint:js": "eslint src scripts server.js --ignore-path .gitignore || exit 0",


### PR DESCRIPTION
It was causing the generated server.js to crash, should fix the broken deployments ([i.e. 1922](https://circleci.com/gh/18F/crime-data-frontend/1922))