### PR TITLE
lat, lng bug fix

### DIFF
--- a/src/components/PlaceThumbnail.js
+++ b/src/components/PlaceThumbnail.js
@@ -35,7 +35,7 @@ class PlaceThumbnail extends React.Component {
       s => s.properties.name.toUpperCase() === placeUpper,
     )
 
-    const { lat, lng } = coordinates
+    const { lat, lng } = coordinates || {}
     const pin = coordinates && projection([lng, lat])
 
     let scale = 1


### PR DESCRIPTION
there was a bug where we assumed coordinates was an object with lat, lng when sometimes it wouldn't for agencies (see https://crime-data-explorer.fr.cloud.gov/explorer/agency/OR0031300/violent-crime)