### PR TITLE
Use offense endpoint to calculate NIBRS total

### DIFF
--- a/src/containers/NibrsContainer.js
+++ b/src/containers/NibrsContainer.js
@@ -71,12 +71,15 @@ const NibrsContainer = ({
   if (error) content = <ErrorCard error={error} />
   else if (isReady) {
     const filteredData = filterNibrsData(data, { since, until })
-    const dataParsed = parseNibrs(filteredData)
+    const dataParsed = parseNibrs(filteredData, crime)
 
-    totalCount = filteredData.offenderRaceCode.reduce((a, b) => a + b.count, 0)
+    totalCount = dataParsed
+      .find(d => d.title === 'Offenses')
+      .data.reduce((accum, next) => accum + next.count, 0)
+
     content = (
       <div className="clearfix mxn1">
-        {dataParsed.map((d, i) => {
+        {dataParsed.filter(d => d.title !== 'Offenses').map((d, i) => {
           const cls = i % 2 === 0 ? 'clear-left' : ''
           return (
             <div key={i} className={`col col-12 sm-col-6 mb2 px1 ${cls}`}>

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -13,6 +13,7 @@ export const API = '/api-proxy'
 const dimensionEndpoints = {
   ageNum: 'age_num',
   locationName: 'location_name',
+  offenseName: 'offense_name',
   raceCode: 'race_code',
   relationship: 'offender_relationship',
   sexCode: 'sex_code',
@@ -20,15 +21,16 @@ const dimensionEndpoints = {
 
 const getAgency = ori => get(`${API}/agencies/${ori}`)
 
-const getNibrs = ({ crime, dim, place, placeType, type }) => {
-  const loc = place === nationalKey
-    ? 'national'
-    : placeType === 'agency'
-      ? `agencies/${place}`
-      : `states/${lookupUsa(place)}`
+const fetchNibrs = ({ crime, dim, place, placeType, type }) => {
+  const loc =
+    place === nationalKey
+      ? 'national'
+      : placeType === 'agency'
+        ? `agencies/${place}`
+        : `states/${lookupUsa(place)}`
 
   const field = dimensionEndpoints[dim] || dim
-  const fieldPath = `${field}/offenses`
+  const fieldPath = dim === 'offenseName' ? field : `${field}/offenses`
   const url = `${API}/${type}s/count/${loc}/${fieldPath}`
 
   const params = {
@@ -52,6 +54,7 @@ const getNibrsRequests = params => {
     { type: 'offender', dim: 'raceCode' },
     { type: 'offender', dim: 'sexCode' },
     { type: 'offense', dim: 'locationName' },
+    { type: 'offense', dim: 'offenseName' },
     { type: 'victim', dim: 'ageNum' },
     { type: 'victim', dim: 'ethnicity' },
     { type: 'victim', dim: 'raceCode' },
@@ -59,7 +62,7 @@ const getNibrsRequests = params => {
     { type: 'victim', dim: 'relationship' },
   ]
 
-  return slices.map(s => getNibrs({ ...s, crime, place, placeType }))
+  return slices.map(s => fetchNibrs({ ...s, crime, place, placeType }))
 }
 
 const fetchResults = (key, path) =>
@@ -122,9 +125,10 @@ const getSummaryRequests = ({ crime, place, placeType }) => {
 }
 
 const getUcrParticipation = place => {
-  const path = place === nationalKey
-    ? 'participation/national'
-    : `participation/states/${lookupUsa(place).toUpperCase()}`
+  const path =
+    place === nationalKey
+      ? 'participation/national'
+      : `participation/states/${lookupUsa(place).toUpperCase()}`
 
   return get(`${API}/${path}`).then(response => ({
     place,
@@ -155,7 +159,7 @@ export default {
   fetchAggregates,
   fetchAgencyAggregates,
   getAgency,
-  getNibrs,
+  fetchNibrs,
   getNibrsRequests,
   getSummaryRequests,
   getUcrParticipation,

--- a/src/util/nibrs.js
+++ b/src/util/nibrs.js
@@ -63,6 +63,27 @@ const locationNameMapping = {
   'Tribal Lands': 'Tribal Lands',
 }
 
+export const offenseMapping = {
+  'aggravated-assault': 'Aggravated Assault',
+  burglary: 'Burglary/Breaking & Entering',
+  larceny: [
+    'Not Specified',
+    'Theft of Motor Vehicle Parts or Accessories',
+    'Pocket-picking',
+    'Theft From Motor Vehicle',
+    'Purse-snatching',
+    'Shoplifting',
+    'All Other Larceny',
+    'Theft From Building',
+    'Theft From Coin-Operated Machine or Device',
+  ],
+  'motor-vehicle-theft': 'Motor Vehicle Theft',
+  homicide: 'Murder and Nonnegligent Manslaughter',
+  rape: ['Rape', 'Sexual Assault With An Object', 'Incest'],
+  robbery: 'Robbery',
+  arson: 'Arson',
+}
+
 // data munging functions
 
 export const reshape = (data, key) => {
@@ -223,11 +244,31 @@ const locations = data => {
   }
 }
 
-const parseNibrs = data => [
+const offenses = (data, offense) => {
+  const nibrsOffense = offenseMapping[offense]
+  const offenseData = data.offenseOffenseName.filter(d => {
+    if (nibrsOffense.forEach) {
+      let isSame = false
+      nibrsOffense.forEach(o => {
+        if (d.offense_name === o) isSame = true
+      })
+      return isSame
+    }
+    return d.offense_name === nibrsOffense
+  })
+
+  return {
+    title: 'Offenses',
+    data: reshape(offenseData, 'offense_name'),
+  }
+}
+
+const parseNibrs = (data, offense) => [
   offenderDemo(data),
   victimDemo(data),
   relationships(data),
   locations(data),
+  offenses(data, offense),
 ]
 
 export default parseNibrs

--- a/test/fixtures/nibrsApiResponse.json
+++ b/test/fixtures/nibrsApiResponse.json
@@ -36,5 +36,9 @@
   "offenseLocationName":[
     {"count":1,"location_name":"Air/Bus/Train Terminal","year":"2006"},
     {"count":1,"location_name":"Air/Bus/Train Terminal","year":"2011"}
+  ],
+  "offenseOffenseName": [
+    {"count":5,"offense_name":"Murder and Nonnegligent Manslaughter","year":"2006"},
+    {"count":2,"offense_name":"Murder and Nonnegligent Manslaughter","year":"2008"}
   ]
 }

--- a/test/util/api.test.js
+++ b/test/util/api.test.js
@@ -51,11 +51,11 @@ describe('api utility', () => {
     })
   })
 
-  describe('getNibrs()', () => {
+  describe('fetchNibrs()', () => {
     it('should call the /offenders/count/states/:postal_abbr/:dim/offenses endpoint', done => {
       const spy = sandbox.stub(http, 'get', () => createPromise(success))
       const args = { ...params, type: 'offender', dim: 'sexCode' }
-      api.getNibrs(args).then(() => {
+      api.fetchNibrs(args).then(() => {
         const spyArgs = spy.args[0]
         const expectedUrl =
           '/api-proxy/offenders/count/states/ca/sex_code/offenses'
@@ -68,7 +68,7 @@ describe('api utility', () => {
     it('should return a data structure with a key and data', done => {
       sandbox.stub(http, 'get', () => createPromise(success))
       const args = { ...params, type: 'offender', dim: 'sexCode' }
-      api.getNibrs(args).then(d => {
+      api.fetchNibrs(args).then(d => {
         expect(d.key).toEqual('offenderSexCode')
         expect(d.data).toEqual(success.results)
         done()
@@ -77,10 +77,10 @@ describe('api utility', () => {
   })
 
   describe('getNibrsRequests()', () => {
-    it('should call getNibrs 10 times', done => {
+    it('should call getNibrs 11 times', done => {
       const spy = sandbox.stub(http, 'get', () => createPromise(success))
       Promise.all(api.getNibrsRequests(params)).then(() => {
-        expect(spy.callCount).toEqual(10)
+        expect(spy.callCount).toEqual(11)
         done()
       })
     })

--- a/test/util/nibrs.test.js
+++ b/test/util/nibrs.test.js
@@ -53,8 +53,7 @@ describe('nibrs utility', () => {
     // TODO: add more robust tests of this function, as right now it just checks
     // for the titles of the sections and not the shape of the data
     it('should parse the data into an array with the proper titles', () => {
-      const actual = parseNibrs(mockApiData)
-      expect(actual.length).toEqual(4)
+      const actual = parseNibrs(mockApiData, 'homicide')
       expect(actual[0].title.toLowerCase()).toEqual('offender demographics')
       expect(actual[1].title.toLowerCase()).toEqual('victim demographics')
       expect(actual[2].title.toLowerCase()).toEqual(


### PR DESCRIPTION
Fixes https://github.com/18F/crime-data-explorer/issues/259

Use the `offense_name` variable for the offense endpoints to get a count. Recreate [the mapping from the API](https://github.com/18F/crime-data-api/blob/master/crime_data/common/base.py#L493-L506) to account for `explorer_offense` not working on that endpoint