### PR TITLE
Change "incidents" to "offenses" in NIBRS

### DIFF
--- a/src/components/ExplorerIntroAgency.js
+++ b/src/components/ExplorerIntroAgency.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import Term from './Term'
-import { nibrsTerm, srsTerm } from './Terms'
+import { NibrsTerm, SrsTerm } from './Terms'
 import mapCrimeToGlossaryTerm from '../util/glossary'
 
 const ExplorerIntroAgency = ({
@@ -26,16 +26,9 @@ const ExplorerIntroAgency = ({
 
   return (
     <p className="serif">
-      The {startCase(name)} is located in
-      {' '}
-      {showCounty && `${county} County, `}
-      {startCase(state)}.
-      {' '}
-      {crimeTerm} totals for this agency are voluntarily submitted to the
-      FBI using
-      {' '}
-      {hasNibrs ? nibrsTerm : srsTerm}
-      {' '}
+      The {startCase(name)} is located in {showCounty && `${county} County, `}
+      {startCase(state)}. {crimeTerm} totals for this agency are voluntarily
+      submitted to the FBI using {hasNibrs ? <NibrsTerm /> : <SrsTerm />}{' '}
       reports.
     </p>
   )

--- a/src/components/NibrsIntro.js
+++ b/src/components/NibrsIntro.js
@@ -5,7 +5,10 @@ import React from 'react'
 import { nibrsTerm } from './Terms'
 import { formatNum } from '../util/formats'
 
-const highlight = txt => <strong>{txt}</strong>
+const highlight = txt =>
+  <strong>
+    {txt}
+  </strong>
 
 const NibrsIntro = ({
   crime,
@@ -20,9 +23,9 @@ const NibrsIntro = ({
   if (isAgency) {
     return (
       <p className="m0 sm-col-9">
-        This agency reported {highlight(formatNum(totalCount))}{' '}
-        individual {crime} {pluralize('incident', totalCount)} to the
-        FBI between {highlight(nibrsFirstYear)} and {highlight(until)}.
+        This agency reported {highlight(formatNum(totalCount))} individual{' '}
+        {crime} {pluralize('offense', totalCount)} to the FBI between{' '}
+        {highlight(nibrsFirstYear)} and {highlight(until)}.
       </p>
     )
   }
@@ -33,10 +36,9 @@ const NibrsIntro = ({
 
   return (
     <p className="m0 sm-col-9">
-      There were {highlight(formatNum(totalCount))} individual{' '}
-      {crime} incidents reported to the FBI in {placeDisplay}{' '}
-      between {highlight(nibrsFirstYear)} and {highlight(until)}{' '}
-      by {highlight(agencyCt)} law enforcement{' '}
+      There were {highlight(formatNum(totalCount))} individual {crime} incidents
+      reported to the FBI in {placeDisplay} between {highlight(nibrsFirstYear)}{' '}
+      and {highlight(until)} by {highlight(agencyCt)} law enforcement{' '}
       {pluralize('agency', agencyCt)} reporting {nibrsTerm} data.
     </p>
   )


### PR DESCRIPTION
We are technically counting the number of reported offenses, not the
number of incidents which has a specific meaning in NIBRS. Incidents
can have many offenses associated with them, and most closely
correlates with a row of data. However, when regular folks are reading
this, the distinction is lost. So we'll use "offenses" since it is
technically more correct and has a very similar meaning to folks not
familiar with the NIBRS definition.