### PR TITLE
Use "Washington, DC" instead of "District of Columbia"

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -10,8 +10,7 @@ import UsaMap from './UsaMap'
 import DownloadDataBtn from './DownloadDataBtn'
 import { showFeedback } from '../actions/feedback'
 import participation from '../util/participation'
-import { slugify } from '../util/text'
-import usa, { data as usaData, nationalKey } from '../util/usa'
+import { data as usaData, nationalKey } from '../util/usa'
 
 const legend = [
   {
@@ -40,19 +39,16 @@ const legend = [
   },
 ]
 
-const stateColors = Object.keys(usaData)
-  .filter(k => slugify(usa(k)) !== nationalKey)
-  .map(k => {
-    const stateName = usa(k)
-    const ucrInfo = participation(stateName)
-    const { 'state-program': stateProgram, nibrs, srs } = ucrInfo
-    const matches = legend.filter(l => l.check(stateProgram, nibrs, srs))
+const stateColors = usaData.filter(k => k.slug !== nationalKey).map(k => {
+  const ucrInfo = participation(k.slug)
+  const { 'state-program': stateProgram, nibrs, srs } = ucrInfo
+  const matches = legend.filter(l => l.check(stateProgram, nibrs, srs))
 
-    return {
-      state: k,
-      color: matches[0].css,
-    }
-  })
+  return {
+    state: k.id,
+    color: matches[0].css,
+  }
+})
 
 const reduceStateColors = (accum, next) => ({
   ...accum,

--- a/src/components/ExplorerIntro.js
+++ b/src/components/ExplorerIntro.js
@@ -16,7 +16,7 @@ const ExplorerIntro = ({ agency, crime, participation, place, until }) => {
         crime={crime}
         hasNibrs={agency.nibrs_months_reported === 12}
         name={agency.agency_name}
-        state={oriToState(place)}
+        usState={oriToState(place)}
         type={agency.agency_type_name}
       />
     )

--- a/src/components/ExplorerIntroAgency.js
+++ b/src/components/ExplorerIntroAgency.js
@@ -7,13 +7,14 @@ import React from 'react'
 import Term from './Term'
 import { NibrsTerm, SrsTerm } from './Terms'
 import mapCrimeToGlossaryTerm from '../util/glossary'
+import lookupUsa from '../util/usa'
 
 const ExplorerIntroAgency = ({
   county,
   crime,
   hasNibrs,
   name,
-  state,
+  usState,
   type,
 }) => {
   const showCounty =
@@ -27,9 +28,9 @@ const ExplorerIntroAgency = ({
   return (
     <p className="serif">
       The {startCase(name)} is located in {showCounty && `${county} County, `}
-      {startCase(state)}. {crimeTerm} totals for this agency are voluntarily
-      submitted to the FBI using {hasNibrs ? <NibrsTerm /> : <SrsTerm />}{' '}
-      reports.
+      {lookupUsa(usState).display}. {crimeTerm} totals for this agency are
+      voluntarily submitted to the FBI using{' '}
+      {hasNibrs ? <NibrsTerm /> : <SrsTerm />} reports.
     </p>
   )
 }
@@ -41,7 +42,7 @@ ExplorerIntroAgency.defaultProps = {
 ExplorerIntroAgency.propTypes = {
   county: PropTypes.string,
   name: PropTypes.string.isRequired,
-  state: PropTypes.string.isRequired,
+  usState: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   hasNibrs: PropTypes.bool,
 }

--- a/src/components/ExplorerIntroState.js
+++ b/src/components/ExplorerIntroState.js
@@ -1,5 +1,4 @@
 import lowerCase from 'lodash.lowercase'
-import startCase from 'lodash.startcase'
 import upperFirst from 'lodash.upperfirst'
 import React from 'react'
 
@@ -8,6 +7,7 @@ import { EstimatedTerm, NibrsTerm, SrsTerm } from './Terms'
 import { formatNum } from '../util/formats'
 import mapCrimeToGlossaryTerm from '../util/glossary'
 import ucrParticipationLookup from '../util/participation'
+import lookupUsa from '../util/usa'
 
 const highlight = txt =>
   <strong>
@@ -37,13 +37,13 @@ const ExplorerIntroState = ({ crime, place, participation, until }) => {
       {!isArson
         ? <div>
             <p className="serif">
-              {crimeTerm} rates for {startCase(place)} are derived from{' '}
+              {crimeTerm} rates for {lookupUsa(place).display} are derived from{' '}
               {reportTerms} reports voluntarily submitted to the FBI.
             </p>
             <p className="serif">
               In {highlight(until)}
               , the FBI <EstimatedTerm /> crime statistics for{' '}
-              {startCase(place)} based on data received from{' '}
+              {lookupUsa(place).display} based on data received from{' '}
               {highlight(formatNum(untilUcr.participating_agencies))} law
               enforcement agencies out of{' '}
               {highlight(formatNum(untilUcr.total_agencies))} agencies in the
@@ -52,12 +52,13 @@ const ExplorerIntroState = ({ crime, place, participation, until }) => {
           </div>
         : <div>
             <p className="serif">
-              {startCase(place)} reports {reportTerms} data to the FBI.
+              {lookupUsa(place).display} reports {reportTerms} data to the FBI.
             </p>
             <p className="serif">
               In {until}, {formatNum(untilUcr.participating_agencies)}{' '}
-              {startCase(place)} law enforcement agencies voluntarily reported
-              data to the FBI. The charts below feature unestimated data.
+              {lookupUsa(place).display} law enforcement agencies voluntarily
+              reported data to the FBI. The charts below feature unestimated
+              data.
             </p>
           </div>}
     </div>

--- a/src/components/LocationFilter.js
+++ b/src/components/LocationFilter.js
@@ -1,4 +1,3 @@
-import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -27,7 +26,7 @@ class LocationFilter extends React.Component {
           ariaControls={ariaControls}
           onChange={onChange}
           onFocus={this.handleLocationFocus}
-          selected={startCase(usState)}
+          selected={usState}
         />
         {showAgencySearch &&
           <AgencySearch

--- a/src/components/LocationFilter.js
+++ b/src/components/LocationFilter.js
@@ -8,12 +8,18 @@ import { nationalKey } from '../util/usa'
 class LocationFilter extends React.Component {
   state = { showResults: false }
 
+  getAgencyName = () => {
+    const { agency } = this.props
+
+    return (agency || {}).agency_name || ''
+  }
+
   handleLocationFocus = () => {
     this.setState({ showResults: false })
   }
 
   render() {
-    const { agency, agencyData, ariaControls, onChange, usState } = this.props
+    const { agencyData, ariaControls, onChange, usState } = this.props
     const { showResults } = this.state
     const showAgencySearch = usState !== nationalKey && agencyData.length > 0
 
@@ -31,7 +37,7 @@ class LocationFilter extends React.Component {
         {showAgencySearch &&
           <AgencySearch
             onChange={onChange}
-            agency={(agency || {}).agency_name || ''}
+            agency={this.getAgencyName()}
             data={agencyData}
             initialShowResults={showResults}
           />}

--- a/src/components/LocationSelect.js
+++ b/src/components/LocationSelect.js
@@ -1,12 +1,7 @@
-import { entries } from 'd3-collection'
-import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { slugify } from '../util/text'
 import { data } from '../util/usa'
-
-const places = entries(data).map(d => startCase(d.value))
 
 const LocationSelect = ({
   ariaControls,
@@ -15,11 +10,12 @@ const LocationSelect = ({
   onFocus,
   selected,
 }) => {
-  const handleChange = e =>
+  const handleChange = e => {
     onChange({
-      place: slugify(e.target.value),
+      place: e.target.value,
       placeType: 'state',
     })
+  }
 
   return (
     <div>
@@ -34,10 +30,16 @@ const LocationSelect = ({
         id="location-select"
         onChange={handleChange}
         onClick={onFocus}
-        value={selected ? startCase(selected) : ''}
+        value={selected || ''}
       >
-        <option value="" disabled>Location</option>
-        {places.map((p, i) => <option key={i}>{p}</option>)}
+        <option value="" disabled>
+          Location
+        </option>
+        {data.map((p, i) =>
+          <option key={i} value={p.slug}>
+            {p.display}
+          </option>,
+        )}
       </select>
     </div>
   )

--- a/src/components/PlaceThumbnail.js
+++ b/src/components/PlaceThumbnail.js
@@ -4,9 +4,13 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { feature, mesh } from 'topojson'
 
+import lookupUsa from '../util/usa'
+
 const Container = ({ children }) =>
   <div className="center bg-white rounded">
-    <div className="aspect-ratio aspect-ratio--4x3">{children}</div>
+    <div className="aspect-ratio aspect-ratio--4x3">
+      {children}
+    </div>
   </div>
 
 class PlaceThumbnail extends React.Component {
@@ -29,10 +33,8 @@ class PlaceThumbnail extends React.Component {
     const path = geoPath().projection(projection)
     const geoStates = feature(usa, usa.objects.units).features
     const meshed = mesh(usa, usa.objects.units, (a, b) => a !== b)
-
-    const placeUpper = usState.toUpperCase()
     const active = geoStates.find(
-      s => s.properties.name.toUpperCase() === placeUpper,
+      s => s.properties.name === lookupUsa(usState).display,
     )
 
     const { lat, lng } = coordinates || {}
@@ -71,7 +73,7 @@ class PlaceThumbnail extends React.Component {
                   key={i}
                   d={path(d)}
                   fill={
-                    d.properties.name.toUpperCase() === placeUpper || !active
+                    d.properties.name === lookupUsa(usState).display || !active
                       ? '#94aabd'
                       : '#dfe6ed'
                   }

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -1,6 +1,5 @@
 import range from 'lodash.range'
 import lowerCase from 'lodash.lowercase'
-import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -8,9 +7,12 @@ import Highlight from './Highlight'
 import Term from './Term'
 import crimeTerm from '../util/glossary'
 import { formatNum, formatOneDec as formatRate } from '../util/formats'
-import { nationalKey } from '../util/usa'
+import lookupUsa, { nationalKey } from '../util/usa'
 
-const highlight = txt => <strong>{txt}</strong>
+const highlight = txt =>
+  <strong>
+    {txt}
+  </strong>
 const borderColor = { borderColor: '#c8d3dd' }
 const cellStyle = { width: 68, ...borderColor }
 
@@ -21,7 +23,9 @@ const getComparison = ({ place, data }) => {
   const diff = (placeRate / nationalRate - 1) * 100
 
   return Math.abs(diff) < threshold
-    ? <span>about the same (within {threshold}%) as</span>
+    ? <span>
+        about the same (within {threshold}%) as
+      </span>
     : <span>
         {<Highlight text={`${diff > 0 ? 'higher' : 'lower'}`} />} than
       </span>
@@ -38,7 +42,11 @@ const TrendChartDetails = ({
 }) => {
   const handleSelectChange = e => updateYear(Number(e.target.value))
   const yearRange = range(since, until + 1)
-  const term = <Term id={crimeTerm(crime)} size="sm">{lowerCase(crime)}</Term>
+  const term = (
+    <Term id={crimeTerm(crime)} size="sm">
+      {lowerCase(crime)}
+    </Term>
+  )
 
   const data = active.filter(d => d.crime !== 'rape-revised')
   const isNational = keys.length === 1
@@ -53,20 +61,22 @@ const TrendChartDetails = ({
   if (isNational) {
     sentence = (
       <span>
-        In {highlight(year)}, there were {highlight(formatRate(rate))}{' '}
-        incidents of {term} per 100,000 people.
+        In {highlight(year)}, there were {highlight(formatRate(rate))} incidents
+        of {term} per 100,000 people.
       </span>
     )
   } else if (crime === 'rape' && revised && revised.rate) {
     sentence = (
       <span>
-        In {highlight(year)}, the rate at which rape was reported using
-        the <Term id={crimeTerm('rape')} size="sm">legacy</Term> definition{' '}
-        was {highlight(formatRate(rate))} per 100,000.
-        Rape was reported using the
-        {' '}
-        <Term id={crimeTerm('rape-revised')} size="sm">revised</Term>
-        {' '}
+        In {highlight(year)}, the rate at which rape was reported using the{' '}
+        <Term id={crimeTerm('rape')} size="sm">
+          legacy
+        </Term>{' '}
+        definition was {highlight(formatRate(rate))} per 100,000. Rape was
+        reported using the{' '}
+        <Term id={crimeTerm('rape-revised')} size="sm">
+          revised
+        </Term>{' '}
         definition at a rate of {highlight(formatRate(revised.rate))} per
         100,000 people.
       </span>
@@ -74,9 +84,9 @@ const TrendChartDetails = ({
   } else {
     sentence = (
       <span>
-        In {highlight(year)}, {startCase(place)}’s {term} rate
-        was {highlight(formatRate(rate))} incidents per 100,000 people.
-        The rate for that year was {comparison} that of the United States.
+        In {highlight(year)}, {lookupUsa(place).display}’s {term} rate was{' '}
+        {highlight(formatRate(rate))} incidents per 100,000 people. The rate for
+        that year was {comparison} that of the United States.
       </span>
     )
   }
@@ -103,7 +113,11 @@ const TrendChartDetails = ({
                   onChange={handleSelectChange}
                   value={year}
                 >
-                  {yearRange.map((y, i) => <option key={i}>{y}</option>)}
+                  {yearRange.map((y, i) =>
+                    <option key={i}>
+                      {y}
+                    </option>,
+                  )}
                 </select>
               </td>
               <td className="pr2 align-middle">Rate</td>
@@ -128,7 +142,7 @@ const TrendChartDetails = ({
                       backgroundColor: colors[i] || '#000',
                     }}
                   />
-                  {startCase(d.place)}
+                  {lookupUsa(d.place).display}
                 </td>
                 <td className="pt1 pr2 align-bottom right-align">
                   <span

--- a/src/components/TrendSourceText.js
+++ b/src/components/TrendSourceText.js
@@ -1,10 +1,10 @@
-import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 import { EstimatedTerm, NibrsTerm, SrsTerm } from './Terms'
 
 import ucrParticipationLookup from '../util/participation'
+import lookupUsa from '../util/usa'
 
 const TrendSourceText = ({ crime, place }) => {
   const isArson = crime === 'arson'
@@ -16,12 +16,13 @@ const TrendSourceText = ({ crime, place }) => {
       {!isArson
         ? <p>
             Source: FBI, <EstimatedTerm size="sm">Estimated</EstimatedTerm> data
-            for {startCase(place)}.
+            for {lookupUsa(place).display}.
           </p>
         : <p>
             Source: Reported {srs && <SrsTerm size="sm" />}
             {hybrid && ' and '}
-            {nibrs && <NibrsTerm size="sm" />} data from {startCase(place)}.
+            {nibrs && <NibrsTerm size="sm" />} data from{' '}
+            {lookupUsa(place).display}.
           </p>}
     </div>
   )

--- a/src/components/UcrResourcesList.js
+++ b/src/components/UcrResourcesList.js
@@ -10,9 +10,10 @@ import lookupUsa, { nationalKey } from '../util/usa'
 const participationCsvLink = (place, type) => {
   if (type === 'agency') return []
 
-  const path = place === nationalKey
-    ? 'participation/national'
-    : `participation/states/${lookupUsa(place).toUpperCase()}`
+  const path =
+    place === nationalKey
+      ? 'participation/national'
+      : `participation/states/${lookupUsa(place).id}`
 
   return [
     {
@@ -48,7 +49,9 @@ const UcrResourcesList = ({ crime, place, placeType }) => {
       <ul className="m0 p0 fs-14 left-bars">
         {links.map((l, i) =>
           <li className="mb1" key={i}>
-            <a href={l.url}>{l.text}</a>
+            <a href={l.url}>
+              {l.text}
+            </a>
           </li>,
         )}
       </ul>

--- a/src/components/UsaMap.js
+++ b/src/components/UsaMap.js
@@ -1,4 +1,3 @@
-import startCase from 'lodash.startcase'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -23,10 +22,10 @@ class UsaMap extends React.Component {
     const { colors, changeColorOnHover, mapClick, place } = this.props
     const { hover } = this.state
 
-    const placeId = place && stateLookup(place).toUpperCase()
+    const placeId = place && stateLookup(place).id
     const svgDataWithNames = svgData.map(s => ({
       ...s,
-      name: startCase(stateLookup(s.id)),
+      name: stateLookup(s.id).display,
     }))
 
     return (
@@ -40,9 +39,8 @@ class UsaMap extends React.Component {
           <title>USA</title>
           <g onClick={mapClick}>
             {svgDataWithNames.map(s => {
-              const defaultClass = s.id === placeId
-                ? 'fill-red-bright'
-                : 'fill-blue-light'
+              const defaultClass =
+                s.id === placeId ? 'fill-red-bright' : 'fill-blue-light'
 
               return (
                 <path

--- a/src/containers/ExplorerHeaderContainer.js
+++ b/src/containers/ExplorerHeaderContainer.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-nested-ternary */
-import startCase from 'lodash.startcase'
 import React from 'react'
 import { connect } from 'react-redux'
 
@@ -7,8 +6,9 @@ import ExplorerIntro from '../components/ExplorerIntro'
 import Loading from '../components/Loading'
 import PlaceThumbnail from '../components/PlaceThumbnail'
 import UcrResourcesList from '../components/UcrResourcesList'
-import { getPlaceInfo } from '../util/place'
 import { getAgency, oriToState } from '../util/agencies'
+import { getPlaceInfo } from '../util/place'
+import lookup from '../util/usa'
 
 const ExplorerHeaderContainer = ({
   agencies,
@@ -23,15 +23,13 @@ const ExplorerHeaderContainer = ({
 }) => {
   const isLoading = isAgency ? agencies.loading : participation.loading
   const usState = isAgency ? oriToState(place) : place
-  const placeDisplay = isAgency ? agency.agency_name : startCase(usState)
+  const placeDisplay = isAgency ? agency.agency_name : lookup(place).display
 
   return (
     <div>
       <div className="items-baseline mt2 mb4">
         <h1 className="flex-auto m0 pb-tiny fs-22 sm-fs-32 border-bottom border-blue-light">
-          {isAgency
-            ? isLoading ? 'Loading agency...' : placeDisplay
-            : startCase(usState)}
+          {isAgency && isLoading ? 'Loading agency...' : placeDisplay}
         </h1>
       </div>
       <div className="mb5 clearfix">
@@ -52,14 +50,11 @@ const ExplorerHeaderContainer = ({
           />
         </div>
         <div className="sm-col sm-col-4 xs-hide">
-          <PlaceThumbnail
-            coordinates={coordinates}
-            usState={startCase(usState)}
-          />
+          <PlaceThumbnail coordinates={coordinates} usState={usState} />
           <div className="mt-tiny fs-12 serif italic">
             {isAgency && !isLoading
-              ? `${placeDisplay}, ${startCase(usState)}`
-              : startCase(usState)}
+              ? `${placeDisplay}, ${lookup(usState).display}`
+              : placeDisplay}
           </div>
         </div>
       </div>

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -13,18 +13,18 @@ import { updateFilters } from '../actions/filters'
 import { oriToState } from '../util/agencies'
 import { crimeTypes } from '../util/offenses'
 import { slugify } from '../util/text'
-import stateLookup from '../util/usa'
+import lookup from '../util/usa'
 import dataPreview from '../../content/preview.yml'
 
 const Home = ({ crime, dispatch, place, placeType, router }) => {
   const isValid = !!(crime && place) || false
-  const usState = placeType !== 'agency' ? place : oriToState(place)
+  const usState = placeType === 'agency' ? oriToState(place) : place
 
   const handleMapClick = e => {
     const id = e.target.getAttribute('id')
     if (!id) return
 
-    const placeNew = { place: slugify(stateLookup(id)), placeType: 'state' }
+    const placeNew = { place: lookup(id).slug, placeType: 'state' }
     dispatch(updateFilters(placeNew))
     dispatch(updateApp({ crime, ...placeNew }, router))
   }
@@ -39,7 +39,9 @@ const Home = ({ crime, dispatch, place, placeType, router }) => {
     dispatch(action)
   }
 
-  const selectLocation = e => dispatch(updateFilters(e))
+  const selectLocation = e => {
+    dispatch(updateFilters(e))
+  }
 
   return (
     <div>

--- a/src/containers/SparklineContainer.js
+++ b/src/containers/SparklineContainer.js
@@ -10,7 +10,7 @@ import ErrorCard from '../components/ErrorCard'
 import Loading from '../components/Loading'
 import Sparkline from '../components/Sparkline'
 import { oriToState } from '../util/agencies'
-import { nationalKey } from '../util/usa'
+import lookupUsa, { nationalKey } from '../util/usa'
 
 const SparklineContainer = ({ crime, since, summaries, until, usState }) => {
   const { data, error, loading } = summaries
@@ -27,7 +27,7 @@ const SparklineContainer = ({ crime, since, summaries, until, usState }) => {
   const sparklines = [
     {
       data: data[usState] || [],
-      place: usState,
+      place: lookupUsa(usState).display,
       url: `/explorer/state/${usState}/${crime}`,
     },
     {
@@ -52,17 +52,22 @@ const SparklineContainer = ({ crime, since, summaries, until, usState }) => {
           <div className="sm-col sm-col-6 mb1 px1" key={i}>
             <div className="p2 bg-blue-lighter flex items-center">
               <div className="flex-none">
-                <h4 className="m0 sans-serif fs-14">{startCase(s.place)}</h4>
+                <h4 className="m0 sans-serif fs-14">
+                  {s.place}
+                </h4>
                 <p className="mb2 mw8 fs-14">
                   {startCase(crime)},{' '}
-                  <span className="nowrap">{since}-{until}</span>
+                  <span className="nowrap">
+                    {since}-{until}
+                  </span>
                 </p>
                 <a
                   className="block btn btn-sm btn-primary fs-12 regular center"
                   href={s.url}
                 >
-                  Explore{' '}
-                  {s.place === 'United States' ? 'national' : 'state'}{' '}
+                  Explore {s.place === 'United States'
+                    ? 'national'
+                    : 'state'}{' '}
                   data
                 </a>
               </div>

--- a/src/containers/TrendContainer.js
+++ b/src/containers/TrendContainer.js
@@ -13,7 +13,7 @@ import TrendSourceText from '../components/TrendSourceText'
 import { generateCrimeReadme } from '../util/content'
 import { getPlaceInfo } from '../util/place'
 import mungeSummaryData from '../util/summary'
-import { nationalKey } from '../util/usa'
+import lookupUsa, { nationalKey } from '../util/usa'
 
 const getContent = ({ crime, places, since, summaries, until }) => {
   const { loading, error } = summaries
@@ -35,7 +35,7 @@ const getContent = ({ crime, places, since, summaries, until }) => {
   const fname = `${place}-${crime}-${since}-${until}`
   const title =
     `Reported ${pluralize(crime)} in ` +
-    `${startCase(place)}, ${since}-${until}`
+    `${lookupUsa(place).display}, ${since}-${until}`
 
   const readme = generateCrimeReadme({ crime, title })
   const crimeNorm = crime === 'rape' ? 'rape-legacy' : crime
@@ -82,7 +82,7 @@ const TrendContainer = ({
     <div className="mb7">
       <div className="mb2 p2 sm-p4 bg-white border-top border-blue border-w8">
         <h2 className="mt0 mb2 sm-mb4 fs-24 sm-fs-28 sans-serif">
-          {startCase(crime)} rate in {startCase(place)}, {since}-{until}
+          {startCase(crime)} rate in {lookupUsa(place).display}, {since}-{until}
         </h2>
         {getContent({ crime, places, since, summaries, until })}
       </div>

--- a/src/util/agencies.js
+++ b/src/util/agencies.js
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase,consistent-return */
 
-import { slugify } from './text'
 import lookupUsa from './usa'
 
 const postalMappingExceptions = {
@@ -11,13 +10,13 @@ const postalMappingExceptions = {
 export const reshapeData = data =>
   Object.keys(data)
     .filter(key => lookupUsa(key))
-    .map(key => ({ key: slugify(lookupUsa(key)), value: data[key] }))
+    .map(key => ({ key: lookupUsa(key).slug, value: data[key] }))
     .reduce((accum, next) => ({ ...accum, [next.key]: next.value }), {})
 
 export const oriToState = ori => {
   const oriAbbr = ori.slice(0, 2).toUpperCase()
   const postalAbbr = postalMappingExceptions[oriAbbr] || oriAbbr
-  return slugify(lookupUsa(postalAbbr))
+  return lookupUsa(postalAbbr).slug
 }
 
 export const agencyDisplay = ({ agency_name, agency_type_name }) => {

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -27,7 +27,7 @@ const fetchNibrs = ({ crime, dim, place, placeType, type }) => {
       ? 'national'
       : placeType === 'agency'
         ? `agencies/${place}`
-        : `states/${lookupUsa(place)}`
+        : `states/${lookupUsa(place).id}`
 
   const field = dimensionEndpoints[dim] || dim
   const fieldPath = dim === 'offenseName' ? field : `${field}/offenses`
@@ -90,7 +90,7 @@ const parseAggregates = ([estimates, arsons]) => ({
 
 const fetchAggregates = place => {
   const estimatesApi = place
-    ? `estimates/states/${lookupUsa(place).toUpperCase()}`
+    ? `estimates/states/${lookupUsa(place).id}`
     : 'estimates/national'
 
   const requests = [
@@ -128,7 +128,7 @@ const getUcrParticipation = place => {
   const path =
     place === nationalKey
       ? 'participation/national'
-      : `participation/states/${lookupUsa(place).toUpperCase()}`
+      : `participation/states/${lookupUsa(place).id}`
 
   return get(`${API}/${path}`).then(response => ({
     place,

--- a/src/util/participation.js
+++ b/src/util/participation.js
@@ -1,11 +1,10 @@
 import offenses from './offenses'
 import { oriToState } from './agencies'
-import { slugify } from './text'
 import lookupUsa from './usa'
 
 import data from '../../public/data/ucr-program-participation.json'
 
-const lookup = state => data[slugify(state)] || {}
+const lookup = state => data[state] || {}
 
 const isValidPlace = (place, placeType) => lookupUsa(place, placeType)
 const isValidCrime = crime => offenses.includes(crime)

--- a/src/util/usa.js
+++ b/src/util/usa.js
@@ -1,68 +1,67 @@
-import lowerCase from 'lodash.lowercase'
+import startCase from 'lodash.startcase'
 
-import { slugify } from '../util/text'
+const nationalKey = 'united-states'
+const data = [
+  { id: 'usa', slug: nationalKey },
+  { id: 'ak', slug: 'alaska' },
+  { id: 'al', slug: 'alabama' },
+  { id: 'ar', slug: 'arkansas' },
+  { id: 'az', slug: 'arizona' },
+  { id: 'ca', slug: 'california' },
+  { id: 'co', slug: 'colorado' },
+  { id: 'ct', slug: 'connecticut' },
+  { id: 'de', slug: 'delaware' },
+  { id: 'fl', slug: 'florida' },
+  { id: 'ga', slug: 'georgia' },
+  { id: 'hi', slug: 'hawaii' },
+  { id: 'ia', slug: 'iowa' },
+  { id: 'id', slug: 'idaho' },
+  { id: 'il', slug: 'illinois' },
+  { id: 'in', slug: 'indiana' },
+  { id: 'ks', slug: 'kansas' },
+  { id: 'ky', slug: 'kentucky' },
+  { id: 'la', slug: 'louisiana' },
+  { id: 'ma', slug: 'massachusetts' },
+  { id: 'md', slug: 'maryland' },
+  { id: 'me', slug: 'maine' },
+  { id: 'mi', slug: 'michigan' },
+  { id: 'mn', slug: 'minnesota' },
+  { id: 'mo', slug: 'missouri' },
+  { id: 'ms', slug: 'mississippi' },
+  { id: 'mt', slug: 'montana' },
+  { id: 'nc', slug: 'north-carolina' },
+  { id: 'nd', slug: 'north-dakota' },
+  { id: 'ne', slug: 'nebraska' },
+  { id: 'nh', slug: 'new-hampshire' },
+  { id: 'nj', slug: 'new-jersey' },
+  { id: 'nm', slug: 'new-mexico' },
+  { id: 'nv', slug: 'nevada' },
+  { id: 'ny', slug: 'new-york' },
+  { id: 'oh', slug: 'ohio' },
+  { id: 'ok', slug: 'oklahoma' },
+  { id: 'or', slug: 'oregon' },
+  { id: 'pa', slug: 'pennsylvania' },
+  { id: 'ri', slug: 'rhode-island' },
+  { id: 'sc', slug: 'south-carolina' },
+  { id: 'sd', slug: 'south-dakota' },
+  { id: 'tn', slug: 'tennessee' },
+  { id: 'tx', slug: 'texas' },
+  { id: 'ut', slug: 'utah' },
+  { id: 'va', slug: 'virginia' },
+  { id: 'vt', slug: 'vermont' },
+  { id: 'wa', slug: 'washington' },
+  { id: 'dc', display: 'Washington, DC', slug: 'washington-dc' },
+  { id: 'wi', slug: 'wisconsin' },
+  { id: 'wv', slug: 'west-virginia' },
+  { id: 'wy', slug: 'wyoming' },
+].map(d => ({
+  ...d,
+  display: d.display || startCase(d.slug),
+}))
 
-const data = {
-  usa: 'united states',
-  ak: 'alaska',
-  al: 'alabama',
-  ar: 'arkansas',
-  az: 'arizona',
-  ca: 'california',
-  co: 'colorado',
-  ct: 'connecticut',
-  dc: 'district of columbia',
-  de: 'delaware',
-  fl: 'florida',
-  ga: 'georgia',
-  hi: 'hawaii',
-  ia: 'iowa',
-  id: 'idaho',
-  il: 'illinois',
-  in: 'indiana',
-  ks: 'kansas',
-  ky: 'kentucky',
-  la: 'louisiana',
-  ma: 'massachusetts',
-  md: 'maryland',
-  me: 'maine',
-  mi: 'michigan',
-  mn: 'minnesota',
-  mo: 'missouri',
-  ms: 'mississippi',
-  mt: 'montana',
-  nc: 'north carolina',
-  nd: 'north dakota',
-  ne: 'nebraska',
-  nh: 'new hampshire',
-  nj: 'new jersey',
-  nm: 'new mexico',
-  nv: 'nevada',
-  ny: 'new york',
-  oh: 'ohio',
-  ok: 'oklahoma',
-  or: 'oregon',
-  pa: 'pennsylvania',
-  ri: 'rhode island',
-  sc: 'south carolina',
-  sd: 'south dakota',
-  tn: 'tennessee',
-  tx: 'texas',
-  ut: 'utah',
-  va: 'virginia',
-  vt: 'vermont',
-  wa: 'washington',
-  wi: 'wisconsin',
-  wv: 'west virginia',
-  wy: 'wyoming',
-}
+const fromAbbr = abbr => data.find(d => d.id === abbr.toLowerCase())
 
-const nationalKey = slugify(data.usa)
-
-const getPlaceNameFromAbbr = abbr => data[abbr.toLowerCase()]
-
-const getPlaceAbbrFromName = name =>
-  Object.keys(data).filter(key => data[key] === name.toLowerCase()).pop()
+const fromSlug = slug => data.find(d => d.slug === slug)
 
 const lookup = (query, type) => {
   if (!query) return null
@@ -70,8 +69,8 @@ const lookup = (query, type) => {
   // TODO: better check for proper agency ids
   if (type === 'agency') return true
 
-  if (query.length <= 3) return getPlaceNameFromAbbr(query)
-  return getPlaceAbbrFromName(lowerCase(query))
+  if (query.length <= 3) return fromAbbr(query)
+  return fromSlug(query)
 }
 
 export { lookup as default, data, nationalKey }

--- a/test/components/LocationFilter.test.js
+++ b/test/components/LocationFilter.test.js
@@ -1,0 +1,53 @@
+/* eslint no-undef: 0 */
+
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import LocationFilter from '../../src/components/LocationFilter'
+
+describe('LocationFilter', () => {
+  describe('getAgencyName()', () => {
+    it('should return agency name if supplied as prop', () => {
+      const props = {
+        agency: { agency_name: 'Foo' },
+        agencyData: [],
+        ariaControls: 'explorer',
+        onChange: () => {},
+        usState: 'kentucky',
+      }
+      const wrapper = shallow(<LocationFilter {...props} />)
+      const actual = wrapper.instance().getAgencyName()
+      expect(actual).toEqual('Foo')
+    })
+
+    it('should return an empty string otherwise', () => {
+      const props = {
+        agency: false,
+        agencyData: [],
+        ariaControls: 'explorer',
+        onChange: () => {},
+        usState: 'kentucky',
+      }
+      const wrapper = shallow(<LocationFilter {...props} />)
+      const actual = wrapper.instance().getAgencyName()
+      expect(actual).toEqual('')
+    })
+  })
+
+  describe('handleLocationFocus()', () => {
+    it('should set showResults state to false', () => {
+      const props = {
+        agency: false,
+        agencyData: [],
+        ariaControls: 'explorer',
+        onChange: () => {},
+        usState: 'kentucky',
+      }
+
+      const wrapper = shallow(<LocationFilter {...props} />)
+      wrapper.setState({ showResults: true })
+      wrapper.instance().handleLocationFocus()
+      expect(wrapper.state().showResults).toEqual(false)
+    })
+  })
+})

--- a/test/util/api.test.js
+++ b/test/util/api.test.js
@@ -100,7 +100,7 @@ describe('api utility', () => {
       const spy = sandbox.stub(http, 'get', () => createPromise(success))
       api.fetchAggregates('california').then(() => {
         const url = spy.args[0].pop()
-        expect(url.includes('/estimates/states/CA')).toEqual(true)
+        expect(url.includes('/estimates/states/ca')).toEqual(true)
         done()
       })
     })

--- a/test/util/usa.test.js
+++ b/test/util/usa.test.js
@@ -1,19 +1,19 @@
 /* eslint no-undef: 0 */
 
-import lookup, { data as states } from '../../src/util/usa'
+import lookup from '../../src/util/usa'
 
 describe('usa utility', () => {
   describe('with an abbreviation', () => {
     it('should return the proper state', () => {
       const expected = 'california'
       const actual = lookup('ca')
-      expect(actual).toEqual(expected)
+      expect(actual.slug).toEqual(expected)
     })
 
     it('should work with uppercase abbreviations', () => {
       const expected = 'california'
       const actual = lookup('CA')
-      expect(actual).toEqual(expected)
+      expect(actual.slug).toEqual(expected)
     })
   })
 
@@ -21,7 +21,7 @@ describe('usa utility', () => {
     it('should return the proper abbreviation', () => {
       const expected = 'ca'
       const actual = lookup('california')
-      expect(actual).toEqual(expected)
+      expect(actual.id).toEqual(expected)
     })
   })
 })


### PR DESCRIPTION
Also change the way that display names are generated for states (and DC) so that they are consistent across the application and come from the USA utility. This change touches a lot of files, but hopefully simplifies things in the long run since it makes display names predictable and reduces the need to remember to use text formatting functions throughout components.

Closes #1008 

cc @svacovsky and @bdstout1617 