### PR TITLE
Add table representation of UCR participation to About page

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-helmet": "^5.1.3",
     "react-redux": "^5.0.1",
     "react-router": "^3.0.0",
+    "reduce-entries": "^1.0.1",
     "redux": "^3.6.0",
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.1.0",

--- a/sass/components/_tables.scss
+++ b/sass/components/_tables.scss
@@ -28,3 +28,7 @@
 .table-striped {
   tbody tr:nth-of-type(even) { background-color: $table-bg-accent; }
 }
+
+.table-striped-white {
+  tbody tr:nth-of-type(even) { background-color: $white; }
+}

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import Helmet from 'react-helmet'
 import { Link } from 'react-router'
+import reduceEntries from 'reduce-entries'
 
 import SharingTags from './SharingTags'
 import Term from './Term'
@@ -50,11 +51,6 @@ const stateColors = usaData.filter(k => k.slug !== nationalKey).map(k => {
     key: k.id,
     program: matches[0].text,
   }
-})
-
-const reduceEntries = (valueKey = 'value') => (accum, next) => ({
-  ...accum,
-  [next.key]: next[valueKey],
 })
 
 class About extends React.Component {

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -45,223 +45,318 @@ const stateColors = usaData.filter(k => k.slug !== nationalKey).map(k => {
   const matches = legend.filter(l => l.check(stateProgram, nibrs, srs))
 
   return {
-    state: k.id,
     color: matches[0].css,
+    display: k.display,
+    key: k.id,
+    program: matches[0].text,
   }
 })
 
-const reduceStateColors = (accum, next) => ({
+const reduceEntries = (valueKey = 'value') => (accum, next) => ({
   ...accum,
-  [next.state]: next.color,
+  [next.key]: next[valueKey],
 })
 
-const agenciesParticiaptionDownloadUrl =
-  'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3/agencies.csv'
+class About extends React.Component {
+  state = { mapShown: true }
 
-const About = ({ dispatch }) =>
-  <div>
-    <Helmet title="CDE :: About" />
-    <SharingTags title="About" />
-    <section className="bg-white">
-      <div className="px2 py7 container mx-auto">
-        <h1 className="mt0 mb4 pb1 fs-28 sm-fs-40 border-bottom border-blue-light">
-          About the Crime Data Explorer
-        </h1>
-        <div className="clearfix">
-          <div className="md-col md-col-9 md-pr7 fs-16 sm-fs-20 serif">
-            <p className="mb2 md-m0">
-              The Crime Data Explorer is part of the FBI’s broader effort to
-              modernize the reporting of national crime data. It allows you to{' '}
-              <a href="explorer/violent-crime" className="underline">
-                view trends
-              </a>,{' '}
-              <a href="/downloads-and-docs" className="underline">
-                download bulk data
-              </a>, and access the{' '}
-              <a href="/api" className="underline">
-                Crime Data API
-              </a>{' '}
-              for reported crime at the national, state, and agency levels.
-            </p>
-          </div>
-          <div className="md-col md-col-3">
-            <h2 className="mt-tiny mb2 fs-18 sm-fs-22">Available data</h2>
-            <ul className="m0 p0 fs-14 sm-fs-16 left-bars">
-              <li className="mb2">
-                <Link to="/downloads-and-docs">Bulk data downloads</Link>
-              </li>
-              <li className="mb2">
-                <a href="/api">Crime data API</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section className="bg-blue-whiter">
-      <div className="px2 py6 bg-lighten-1">
-        <div className="container mx-auto">
-          <h2 className="mt0 mb5 pb1 fs-22 sm-fs-32 border-bottom border-blue-light">
-            How states participate
-          </h2>
-          <div className="mb4 clearfix">
-            <div className="md-col md-col-9 md-pr7">
-              <UsaMap
-                colors={stateColors.reduce(reduceStateColors, {})}
-                changeColorOnHover={false}
-              />
+  componentDidUpdate(prevProps, prevState) {
+    const { mapShown } = this.state
+    const otherType = mapShown ? 'table' : 'map'
+    if (mapShown !== prevState.mapShown) {
+      const other = this.els.find(el => el.type === otherType)
+      if (other) other.el.focus()
+    }
+  }
+
+  els = []
+
+  handleClick = e => {
+    const { id } = e.target
+    switch (id) {
+      case 'btn-toggle-map':
+        this.setState({ mapShown: true })
+        break
+      case 'btn-toggle-table':
+        this.setState({ mapShown: false })
+        break
+      default:
+        break
+    }
+  }
+
+  render() {
+    const { dispatch } = this.props
+    const { mapShown } = this.state
+    const toggles = [
+      { disabled: !mapShown, type: 'table' },
+      { disabled: mapShown, type: 'map' },
+    ]
+    return (
+      <div>
+        <Helmet title="CDE :: About" />
+        <SharingTags title="About" />
+        <section className="bg-white">
+          <div className="px2 py7 container mx-auto">
+            <h1 className="mt0 mb4 pb1 fs-28 sm-fs-40 border-bottom border-blue-light">
+              About the Crime Data Explorer
+            </h1>
+            <div className="clearfix">
+              <div className="md-col md-col-9 md-pr7 fs-16 sm-fs-20 serif">
+                <p className="mb2 md-m0">
+                  The Crime Data Explorer is part of the FBI’s broader effort to
+                  modernize the reporting of national crime data. It allows you
+                  to{' '}
+                  <a href="explorer/violent-crime" className="underline">
+                    view trends
+                  </a>,{' '}
+                  <a href="/downloads-and-docs" className="underline">
+                    download bulk data
+                  </a>, and access the{' '}
+                  <a href="/api" className="underline">
+                    Crime Data API
+                  </a>{' '}
+                  for reported crime at the national, state, and agency levels.
+                </p>
+              </div>
+              <div className="md-col md-col-3">
+                <h2 className="mt-tiny mb2 fs-18 sm-fs-22">Available data</h2>
+                <ul className="m0 p0 fs-14 sm-fs-16 left-bars">
+                  <li className="mb2">
+                    <Link to="/downloads-and-docs">Bulk data downloads</Link>
+                  </li>
+                  <li className="mb2">
+                    <a href="/api">Crime data API</a>
+                  </li>
+                </ul>
+              </div>
             </div>
-            <div className="md-col md-col-3 pt1 relative table-cell">
-              <div className="">
-                {legend
-                  .map(d => ({
-                    ...d,
-                    count: stateColors.filter(s => s.color === d.css).length,
-                  }))
-                  .map((d, i) =>
-                    <div key={i} className="flex mt2 fs-14">
-                      <div
-                        className="flex-none mt-tiny mr1 circle"
-                        style={{
-                          width: 16,
-                          height: 16,
-                          backgroundColor: d.hex,
-                        }}
-                      />
-                      <div className="flex-auto">
-                        <div className="bold monospace">
-                          {`${d.count} State${d.count !== 1 ? 's' : ''}`}
-                        </div>
-                        <div>
-                          {d.text}
-                        </div>
-                      </div>
-                    </div>,
+          </div>
+        </section>
+        <section className="bg-blue-whiter">
+          <div className="px2 py6 bg-lighten-1">
+            <div className="container mx-auto">
+              <div className="border-bottom border-blue-light clearfix mt0 mb5 pb1">
+                <h2 className="fs-22 sm-fs-32 col col-12 md-col-6 mt0">
+                  How states participate
+                </h2>
+                <div className="fs-12 col col-12 md-col-6">
+                  {toggles.map(b =>
+                    <button
+                      aria-controls="us-ucr-participation"
+                      className={`btn col-6 md-col-4 right ${b.disabled
+                        ? 'regular'
+                        : ''}`}
+                      id={`btn-toggle-${b.type}`}
+                      key={b.type}
+                      onClick={this.handleClick}
+                      disabled={b.disabled}
+                      ref={el => {
+                        if (this.els.length >= toggles.length) return
+                        this.els.push({ ...b, el })
+                      }}
+                    >
+                      View as {b.type}
+                    </button>,
                   )}
+                </div>
               </div>
-              <div className="mt6 pt2 fs-14 border-top border-blue-light">
-                To see which agencies submit NIBRS data to the FBI, download
-                <DownloadDataBtn
-                  data={[{ url: agenciesParticiaptionDownloadUrl }]}
-                  text="Agency participation data"
-                />
+              <div className="mb4 clearfix" id="us-ucr-participation">
+                {mapShown
+                  ? <ParticipationMap states={stateColors} />
+                  : <ParticipationTable states={stateColors} />}
               </div>
             </div>
           </div>
-          <div className="md-col-8 fs-12 serif italic">
-            Territories including American Samoa, Puerto Rico, Guam, and the
-            U.S. Virgin Islands submit summary data to the FBI. Some agencies
-            submit data directly to the FBI.
-          </div>
-        </div>
-      </div>
-    </section>
-    <section className="bg-white">
-      <div className="px2 py7 container mx-auto">
-        <h2 className="mt0 mb4 pb1 fs-22 sm-fs-32 border-bottom border-blue-light">
-          Crime data
-        </h2>
-        <div className="clearfix">
-          <div className="md-col md-col-9 md-pr7 fs-16 sm-fs-20 serif">
-            <p className="mb3">
-              Since 1930, participating local, county, state, tribal, and
-              federal law enforcement agencies have voluntarily provided the
-              nation with crime statistics through the{' '}
-              <a href="https://ucr.fbi.gov/" className="underline">
-                Uniform Crime Reporting (UCR) Program
-              </a>{' '}
-              via:
-            </p>
-            <div className="mb-tiny bold">
-              Summary (SRS) data
-              <span className="italic ml-tiny regular">
-                1960—2014 data available
-              </span>
+        </section>
+        <section className="bg-white">
+          <div className="px2 py7 container mx-auto">
+            <h2 className="mt0 mb4 pb1 fs-22 sm-fs-32 border-bottom border-blue-light">
+              Crime data
+            </h2>
+            <div className="clearfix">
+              <div className="md-col md-col-9 md-pr7 fs-16 sm-fs-20 serif">
+                <p className="mb3">
+                  Since 1930, participating local, county, state, tribal, and
+                  federal law enforcement agencies have voluntarily provided the
+                  nation with crime statistics through the{' '}
+                  <a href="https://ucr.fbi.gov/" className="underline">
+                    Uniform Crime Reporting (UCR) Program
+                  </a>{' '}
+                  via:
+                </p>
+                <div className="mb-tiny bold">
+                  Summary (SRS) data
+                  <span className="italic ml-tiny regular">
+                    1960—2014 data available
+                  </span>
+                </div>
+                <p className="mb3">
+                  Summary data allows us to show crime rates as trends and
+                  totals. This data includes the number of offenses that were
+                  reported on a state or agency level. It captures the most
+                  serious offense involved in crime incidents according to the{' '}
+                  <Term id="hierarchy rule">hierarchy rule</Term> and
+                  supplemental details depending on the offense. For example,
+                  victim and offender data are collected only for murder
+                  offenses.
+                </p>
+                <div className="mb-tiny bold">
+                  Incident-based (NIBRS) data
+                  <span className="italic ml-tiny regular">
+                    1991—2014 data available
+                  </span>
+                </div>
+                <p>
+                  Incident-based data allow us to visualize how crime breaks
+                  down regarding victims, offenders, and other attributes
+                  related to a reported crime. NIBRS data records details
+                  regarding individual offenses and arrests that were part of an
+                  incident, such as information about the victim, offender,
+                  property involved, and arrestees, providing context that is
+                  not provided by the summary data.
+                </p>
+                <p>
+                  The Crime Data Explorer makes this data available through the{' '}
+                  <a href="/api" className="underline">
+                    API
+                  </a>{' '}
+                  and{' '}
+                  <a href="/downloads-and-docs" className="underline">
+                    bulk downloads
+                  </a>.
+                </p>
+              </div>
+              <div className="md-col md-col-3">
+                <h3 className="mt-tiny mb2 fs-18 sm-fs-22">
+                  UCR Program Resources
+                </h3>
+                <ul className="m0 p0 fs-14 sm-fs-16 left-bars">
+                  <li className="mb1">
+                    <a href="https://ucr.fbi.gov/">UCR Home</a>
+                  </li>
+                  <li className="mb1">
+                    <a href="https://ucr.fbi.gov/new-ucr-project">
+                      New UCR Project
+                    </a>
+                  </li>
+                  <li className="mb1">
+                    <a href="https://ucr.fbi.gov/nibrs/nibrs-user-manual">
+                      NIBRS User Manual
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
-            <p className="mb3">
-              Summary data allows us to show crime rates as trends and totals.
-              This data includes the number of offenses that were reported on a
-              state or agency level. It captures the most serious offense
-              involved in crime incidents according to the{' '}
-              <Term id="hierarchy rule">hierarchy rule</Term> and supplemental
-              details depending on the offense. For example, victim and offender
-              data are collected only for murder offenses.
-            </p>
-            <div className="mb-tiny bold">
-              Incident-based (NIBRS) data
-              <span className="italic ml-tiny regular">
-                1991—2014 data available
-              </span>
+          </div>
+        </section>
+        <section className="bg-blue-whiter">
+          <div className="px2 py7 container mx-auto">
+            <h2 className="mt0 mb4 pb1 fs-22 sm-fs-32 border-bottom border-blue-light">
+              More to come
+            </h2>
+            <div className="mb3 md-pr7 border-box serif">
+              <p className="mb3 fs-16 sm-fs-20 md-col-9">
+                The Crime Data Explorer is part of an ongoing effort to improve
+                and provide access to the nation’s crime statistics. We’re
+                working to add new features and value your feedback. Tell us
+                what you’d like to see next.
+              </p>
             </div>
-            <p>
-              Incident-based data allow us to visualize how crime breaks down
-              regarding victims, offenders, and other attributes related to a
-              reported crime. NIBRS data records details regarding individual
-              offenses and arrests that were part of an incident, such as
-              information about the victim, offender, property involved, and
-              arrestees, providing context that is not provided by the summary
-              data.
-            </p>
-            <p>
-              The Crime Data Explorer makes this data available through the{' '}
-              <a href="/api" className="underline">
-                API
-              </a>{' '}
-              and{' '}
-              <a href="/downloads-and-docs" className="underline">
-                bulk downloads
-              </a>.
-            </p>
+            <button
+              className="btn btn-primary"
+              onClick={() => dispatch(showFeedback())}
+              type="button"
+            >
+              Submit feedback
+            </button>
           </div>
-          <div className="md-col md-col-3">
-            <h3 className="mt-tiny mb2 fs-18 sm-fs-22">
-              UCR Program Resources
-            </h3>
-            <ul className="m0 p0 fs-14 sm-fs-16 left-bars">
-              <li className="mb1">
-                <a href="https://ucr.fbi.gov/">UCR Home</a>
-              </li>
-              <li className="mb1">
-                <a href="https://ucr.fbi.gov/new-ucr-project">
-                  New UCR Project
-                </a>
-              </li>
-              <li className="mb1">
-                <a href="https://ucr.fbi.gov/nibrs/nibrs-user-manual">
-                  NIBRS User Manual
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
+        </section>
       </div>
-    </section>
-    <section className="bg-blue-whiter">
-      <div className="px2 py7 container mx-auto">
-        <h2 className="mt0 mb4 pb1 fs-22 sm-fs-32 border-bottom border-blue-light">
-          More to come
-        </h2>
-        <div className="mb3 md-pr7 border-box serif">
-          <p className="mb3 fs-16 sm-fs-20 md-col-9">
-            The Crime Data Explorer is part of an ongoing effort to improve and
-            provide access to the nation’s crime statistics. We’re working to
-            add new features and value your feedback. Tell us what you’d like to
-            see next.
-          </p>
-        </div>
-        <button
-          className="btn btn-primary"
-          onClick={() => dispatch(showFeedback())}
-          type="button"
-        >
-          Submit feedback
-        </button>
-      </div>
-    </section>
-  </div>
+    )
+  }
+}
 
 About.propTypes = {
   dispatch: PropTypes.func,
 }
+
+const ParticipationMap = ({ states }) =>
+  <div>
+    <div className="md-col md-col-9 md-pr7">
+      <UsaMap
+        colors={states.reduce(reduceEntries('color'), {})}
+        changeColorOnHover={false}
+      />
+    </div>
+    <div className="md-col md-col-3 pt1 relative table-cell">
+      <div className="">
+        {legend
+          .map(d => ({
+            ...d,
+            count: states.filter(s => s.color === d.css).length,
+          }))
+          .map((d, i) =>
+            <div key={i} className="flex mt2 fs-14">
+              <div
+                className="flex-none mt-tiny mr1 circle"
+                style={{
+                  width: 16,
+                  height: 16,
+                  backgroundColor: d.hex,
+                }}
+              />
+              <div className="flex-auto">
+                <div className="bold monospace">
+                  {`${d.count} State${d.count !== 1 ? 's' : ''}`}
+                </div>
+                <div>
+                  {d.text}
+                </div>
+              </div>
+            </div>,
+          )}
+      </div>
+      <div className="mt6 pt2 fs-14 border-top border-blue-light">
+        To see which agencies submit NIBRS data to the FBI, download
+        <DownloadDataBtn
+          data={[
+            {
+              url:
+                'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3/agencies.csv',
+            },
+          ]}
+          text="Agency participation data"
+        />
+      </div>
+    </div>
+    <div className="md-col-8 fs-12 serif italic">
+      Territories including American Samoa, Puerto Rico, Guam, and the U.S.
+      Virgin Islands submit summary data to the FBI. Some agencies submit data
+      directly to the FBI.
+    </div>
+  </div>
+
+const ParticipationTable = ({ states }) =>
+  <table className="table-striped-white">
+    <thead>
+      <tr className="lh-32">
+        <th className="align-top pl1">State</th>
+        <th>Data type submitted to the FBI</th>
+      </tr>
+    </thead>
+    <tbody>
+      {states.map((s, i) =>
+        <tr className="lh-32" key={i}>
+          <td className="pl1">
+            {s.display}
+          </td>
+          <td>
+            {s.program}
+          </td>
+        </tr>,
+      )}
+    </tbody>
+  </table>
 
 export default About


### PR DESCRIPTION
Adds a tabular representation of the UCR participation data for a11y (fixes #1173) and mobile users. Needs to be merged after #1184 

![resizing-about](https://user-images.githubusercontent.com/780941/28851590-9c56b7f4-76f1-11e7-86b8-63a4b756f73c.gif)
![toggle-about](https://user-images.githubusercontent.com/780941/28851589-9c52702c-76f1-11e7-887c-2b78347b96f5.gif)
