### PR TITLE
Agency & summary utils & summary actions use reduce-entries

### DIFF
--- a/src/actions/summary.js
+++ b/src/actions/summary.js
@@ -1,6 +1,7 @@
+import reduceEntries from 'reduce-entries'
+
 import { SUMMARY_FAILED, SUMMARY_FETCHING, SUMMARY_RECEIVED } from './constants'
 import api from '../util/api'
-import { reshapeData } from '../util/summary'
 
 export const failedSummary = error => ({
   type: SUMMARY_FAILED,
@@ -21,7 +22,7 @@ export const fetchSummaries = params => dispatch => {
   const requests = api.getSummaryRequests(params)
 
   return Promise.all(requests)
-    .then(data => reshapeData(data))
+    .then(data => data.reduce(reduceEntries('results')))
     .then(summaries => dispatch(receivedSummary(summaries)))
     .catch(error => dispatch(failedSummary(error)))
 }

--- a/src/util/agencies.js
+++ b/src/util/agencies.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase,consistent-return */
+import reduceEntries from 'reduce-entries'
 
 import lookupUsa from './usa'
 
@@ -11,7 +12,7 @@ export const reshapeData = data =>
   Object.keys(data)
     .filter(key => lookupUsa(key))
     .map(key => ({ key: lookupUsa(key).slug, value: data[key] }))
-    .reduce((accum, next) => ({ ...accum, [next.key]: next.value }), {})
+    .reduce(reduceEntries())
 
 export const oriToState = ori => {
   const oriAbbr = ori.slice(0, 2).toUpperCase()

--- a/src/util/summary.js
+++ b/src/util/summary.js
@@ -1,8 +1,5 @@
 import snakeCase from 'lodash.snakecase'
 
-export const reshapeData = dataIn =>
-  Object.assign(...dataIn.map(d => ({ [d.key]: d.results })))
-
 // todo: refactor into action/reducer
 // build all rates and stuff in reducer/action
 
@@ -19,9 +16,8 @@ const mungeSummaryData = ({ crime, summaries, place, since, until }) => {
     .map(year => {
       const data = { year: +year.year }
       keys.forEach(key => {
-        const source = key !== place
-          ? summaries[key].find(d => +d.year === data.year)
-          : year
+        const source =
+          key !== place ? summaries[key].find(d => +d.year === data.year) : year
         const normalizedCrime = crime === 'rape' ? 'rape-legacy' : crime
         const apiCrime = snakeCase(normalizedCrime)
 

--- a/test/util/participation.test.js
+++ b/test/util/participation.test.js
@@ -4,6 +4,7 @@ import dataSourcesReportedByState, {
   shouldFetchUcr,
   shouldFetchSummaries,
   shouldFetchNibrs,
+  reshapeData,
 } from '../../src/util/participation'
 import { nationalKey } from '../../src/util/usa'
 
@@ -86,6 +87,15 @@ describe('ucr utility', () => {
       expect(
         Object.prototype.hasOwnProperty.call(result, 'initial-year'),
       ).toEqual(true)
+    })
+  })
+
+  describe('reshapeData()', () => {
+    it('should return a single object from an array of objects', () => {
+      const actual = reshapeData([
+        { place: 'fake-place', results: 'fake-results' },
+      ])
+      expect(actual).toEqual({ 'fake-place': 'fake-results' })
     })
   })
 })


### PR DESCRIPTION
Refactor to use a common library instead of duplicated code and add tests to another another similar function in participation util