### PR TITLE
Refactor mungeSummaryData util function

### DIFF
--- a/src/actions/summary.js
+++ b/src/actions/summary.js
@@ -2,7 +2,7 @@ import reduceEntries from 'reduce-entries'
 
 import { SUMMARY_FAILED, SUMMARY_FETCHING, SUMMARY_RECEIVED } from './constants'
 import api from '../util/api'
-import mungeSummaryData, { calculateRates, reshapeData } from '../util/summary'
+import { calculateRates, reshapeData } from '../util/summary'
 
 export const failedSummary = error => ({
   type: SUMMARY_FAILED,

--- a/src/util/summary.js
+++ b/src/util/summary.js
@@ -1,53 +1,6 @@
-import snakeCase from 'lodash.snakecase'
-
 import { slugify } from '../util/text'
 
-const reshapeData = dataIn =>
-  Object.assign(...dataIn.map(d => ({ [d.key]: d.results })))
-
-// todo: refactor into action/reducer
-// build all rates and stuff in reducer/action
-
-const mungeSummaryData = (filter, summaries) => {
-  if (!summaries || !summaries[filter.place]) return false
-
-  const keys = Object.keys(summaries)
-  // return summaries[filter.place]
-  //   .filter(d => {
-  //     if (!filter.since || !filter.until) return true
-  //     return d.year >= filter.since && d.year <= filter.until
-  //   })
-  //   .sort((a, b) => a.year - b.year)
-  return keys.map(year => {
-    const data = { year: +year.year }
-    keys.forEach(key => {
-      const source =
-        key !== filter.place
-          ? summaries[key].find(d => +d.year === data.year)
-          : year
-      const normalizedCrime =
-        filter.crime === 'rape' ? 'rape-legacy' : filter.crime
-      const apiCrime = snakeCase(normalizedCrime)
-      data[key] = {
-        population: source.population,
-        [normalizedCrime]: {
-          count: source[apiCrime],
-          rate: source[apiCrime] / source.population * 100000,
-        },
-      }
-
-      if (filter.crime === 'rape') {
-        data[key]['rape-revised'] = {
-          count: source.rape_revised,
-          rate: source.rape_revised / source.population * 100000,
-        }
-      }
-    })
-    return data
-  })
-}
-
-const calculateRates = summaries => {
+export const calculateRates = summaries => {
   const nonOffenseKeys = ['caveats', 'population', 'state_abbr', 'year']
   const places = Object.keys(summaries).map(place => {
     const rates = summaries[place].map(yearly => {
@@ -73,45 +26,11 @@ const calculateRates = summaries => {
   return Object.assign(...places)
 }
 
-const filterByYear = (summaries, { since, until }) => {
-  const places = Object.keys(summaries).map(place => {
-    const filtered = summaries[place].filter(y => {
-      const { year } = y
-      if (since && until && +year >= since && +year <= until) return true
-      else if (since && !until && since >= +year) return true
-      else if (!since && until && until <= +year) return true
-      return false
-    })
-    return {
-      [place]: filtered,
-    }
-  })
-
-  console.log('places', places)
-
-  return Object.assign(...places)
-}
-
-/*
-
-starting:
-{ place: [ { pop, year, offense: { rate, count }}]}
-
-goal:
- [{ year, place: '', trend: { [offense]: { rate, count }, population }... } ]
-
-*/
-
-// take the summaries object, which has places as keys
-// create an array of new objects, one for each year
-// inside each new year object, should be the place names as keys as well as the year
-// the values of those keys should be another object that has a key per offense and the place population that year
-// each offense should have a value of another object with rate and count
-
-const combinePlaces = (summaries, offenses = []) => {
+export const combinePlaces = (summaries, offenses = []) => {
   const places = Object.keys(summaries)
   const years = summaries[places[0]].map(y => y.year)
-  const x = years.map(year =>
+
+  return years.map(year =>
     Object.assign(
       { year },
       ...places.map(place => {
@@ -120,50 +39,29 @@ const combinePlaces = (summaries, offenses = []) => {
         offenses.forEach(offense => {
           o[offense] = yearData[offense]
         })
+
         return { [place]: { population: yearData.population, ...o } }
       }),
     ),
   )
-
-  console.log('x!', x)
-
-  return x
 }
 
-//
-// const computeTrend = (place, summaries) => {
-//   console.log('Compute Trend for place:' + place + ' Data:', summaries)
-//   const locData = summaries[place]
-//   console.log('Location Data:', locData)
-//   const trendData = []
-//   console.log('offnse Data:', internal_offenses)
-//   locData.forEach(d => {
-//     const yrData = {}
-//     yrData.year = d.year
-//     yrData.population = d.population
-//     const keys = Object.keys(d)
-//     keys.forEach(key => {
-//       console.log(snakeCase(key))
-//       if (internal_offenses.hasOwnProperty(snakeCase(key))) {
-//         const crimeData = {}
-//         const rate = {
-//           rate: d[key] * 10000 / d.population,
-//         }
-//         //console.log("Computed Rate:", rate);
-//         crimeData.rate = rate
-//         yrData[key] = crimeData
-//         console.log('Year Data Obj:', yrData)
-//       }
-//     })
-//     trendData.push(yrData)
-//   })
-//   summaries.trendData = trendData
-//   return summaries
-// }
-export {
-  mungeSummaryData as default,
-  calculateRates,
-  combinePlaces,
-  filterByYear,
-  reshapeData,
+export const filterByYear = (summaries, { since, until }) => {
+  const places = Object.keys(summaries).map(place => {
+    const filtered = summaries[place].filter(y => {
+      const { year } = y
+      if (since && until && +year >= since && +year <= until) return true
+      else if (since && !until && since <= +year) return true
+      else if (!since && until && until >= +year) return true
+      return false
+    })
+    return {
+      [place]: filtered,
+    }
+  })
+
+  return Object.assign(...places)
 }
+
+export const reshapeData = dataIn =>
+  Object.assign(...dataIn.map(d => ({ [d.key]: d.results })))

--- a/test/actions/summary.test.js
+++ b/test/actions/summary.test.js
@@ -14,6 +14,7 @@ import {
   receivedSummary,
 } from '../../src/actions/summary'
 import api from '../../src/util/api'
+import * as summaryUtil from '../../src/util/summary'
 import { nationalKey } from '../../src/util/usa'
 
 const createPromise = (res, err) => {
@@ -100,6 +101,7 @@ describe('summary action', () => {
           results: ['fake-two'],
         }),
       ])
+      sandbox.stub(summaryUtil, 'calculateRates', x => x)
       fetchSummaries({ place: 'montana' })(dispatch).then(() => {
         const args = dispatch.args[1][0]
         expect(args.type).toEqual(SUMMARY_RECEIVED)

--- a/test/util/summary.test.js
+++ b/test/util/summary.test.js
@@ -1,97 +1,135 @@
 /* eslint no-undef: 0 */
 
-import mungeSummaryData from '../../src/util/summary'
+import {
+  calculateRates,
+  combinePlaces,
+  filterByYear,
+  reshapeData,
+} from '../../src/util/summary'
 
-describe('summary data munging utility', () => {
-  it('should return false if summaries is not supplied', () => {
-    const crime = 'violent-crime'
-    expect(mungeSummaryData({ summaries: null, crime })).toEqual(false)
-  })
-
-  it('should return false if summaries[place] is not supplied', () => {
-    const crime = 'violent-crime'
-    const summaries = {}
-    const place = 'california'
-    expect(mungeSummaryData({ crime, summaries, place })).toEqual(false)
-  })
-
-  it('should filter data to be inclusive of since and until, if provided', () => {
-    const data = [
-      { year: 2014, violent_crime: 10, population: 100 },
-      { year: 2013, violent_crime: 10, population: 100 },
-      { year: 2012, violent_crime: 10, population: 100 },
-      { year: 2011, violent_crime: 10, population: 100 },
-      { year: 2010, violent_crime: 10, population: 100 },
-    ]
-    const crime = 'violent-crime'
-    const summaries = { california: data, 'united-states': data }
-    const place = 'california'
-    const actual = mungeSummaryData({
-      crime,
-      summaries,
-      place,
-      since: 2013,
-      until: 2014,
-    })
-    expect(actual.length).toEqual(2)
-  })
-
-  it('should sort the data by date', () => {
-    const data = [
-      { year: 2011, violent_crime: 10, population: 100 },
-      { year: 2013, violent_crime: 10, population: 100 },
-      { year: 2012, violent_crime: 10, population: 100 },
-    ]
-
-    const actual = mungeSummaryData({
-      crime: 'violent-crime',
-      summaries: { california: data, 'united-states': data },
-      place: 'california',
-      since: 2011,
-      until: 2013,
-    })
-    const actualYears = actual.map(a => a.year)
-
-    expect(actualYears[0]).toEqual(2011)
-    expect(actualYears[2]).toEqual(2013)
-  })
-
-  it('should reshape the data', () => {
-    const crime = 'violent-crime'
-    const summaries = {
-      california: [{ year: 2014, violent_crime: 10, population: 100 }],
-      'united-states': [{ year: 2014, violent_crime: 10, population: 100 }],
-    }
-    const place = 'california'
-    expect(mungeSummaryData({ crime, summaries, place })).toEqual([
-      {
-        year: 2014,
-        california: { [crime]: { count: 10, rate: 10000 }, population: 100 },
-        'united-states': {
-          [crime]: { count: 10, rate: 10000 },
-          population: 100,
-        },
-      },
-    ])
-  })
-
-  it('should return data for both rape definitions', () => {
-    const crime = 'rape'
-    const summaries = {
+describe('summary util', () => {
+  describe('calculateRates()', () => {
+    const createApiResponse = () => ({
       'united-states': [
-        { year: 2014, rape_legacy: 10, rape_revised: 10, population: 100 },
-      ],
-    }
-    const place = 'united-states'
-    expect(mungeSummaryData({ crime, summaries, place })).toEqual([
-      {
-        year: 2014,
-        'united-states': {
-          'rape-legacy': { count: 10, rate: 10000 },
-          'rape-revised': { count: 10, rate: 10000 },
-          population: 100,
+        {
+          year: 2010,
+          population: 1000,
+          violent_crime: 5,
+          robbery: 5,
         },
-      },
-    ])
+      ],
+    })
+    it('should add rates to all offenses', () => {
+      const resp = createApiResponse()
+      const actual = calculateRates(resp)['united-states'][0]
+      const expected = { count: 5, rate: 500 }
+      expect(actual['violent-crime']).toEqual(expected)
+      expect(actual.robbery).toEqual(expected)
+    })
+
+    it('should ignore certain keys such as population', () => {
+      const resp = createApiResponse()
+      const actual = calculateRates(resp)['united-states'][0]
+      expect(actual.population).toEqual(1000)
+    })
+  })
+
+  describe('combinePlaces()', () => {
+    const places = ['united-states', 'california']
+    const years = [2010, 2011, 2012, 2013, 2014]
+    const createApiResponse = () =>
+      Object.assign(
+        {},
+        ...places.map(place => ({
+          [place]: years.map(year => ({
+            year,
+            population: 1000,
+            'violent-crime': {
+              count: 5,
+              rate: 10,
+            },
+            robbery: {
+              count: 5,
+              rate: 10,
+            },
+          })),
+        })),
+      )
+
+    it('should return an array where each object has keys for the year and the places', () => {
+      const resp = createApiResponse()
+      const actual = combinePlaces(resp, ['violent-crime'])
+
+      const first = Object.keys(actual[0])
+      const last = Object.keys(actual[actual.length - 1])
+
+      expect(first.includes('year')).toEqual(true)
+      expect(first.includes('california')).toEqual(true)
+      expect(first.includes('united-states')).toEqual(true)
+
+      expect(last.includes('year')).toEqual(true)
+      expect(last.includes('california')).toEqual(true)
+      expect(last.includes('united-states')).toEqual(true)
+    })
+
+    it('should return an array where each object has the rate and counts for offenses', () => {
+      const resp = createApiResponse()
+      const actual = combinePlaces(resp, ['violent-crime', 'robbery'])
+
+      const hasOffenseObject = actual.filter(a => {
+        if (
+          a['united-states']['violent-crime'].count &&
+          a['united-states']['violent-crime'].rate &&
+          a['united-states'].robbery.count &&
+          a['united-states'].robbery.rate
+        ) {
+          return true
+        }
+        return false
+      })
+      expect(hasOffenseObject.length).toEqual(actual.length)
+    })
+  })
+
+  describe('filterByYear()', () => {
+    const years = [2010, 2011, 2012, 2013, 2014]
+    const createApiResponse = () => ({
+      'united-states': years.map(year => ({
+        year,
+        population: 1000,
+        violent_crime: 5,
+        robbery: 5,
+      })),
+    })
+    it('should return data, incusively, where year is more recent than since', () => {
+      const resp = createApiResponse()
+      const actual = filterByYear(resp, { since: 2012 })
+      const hasEarlier = actual['united-states'].find(y => y.year === 2010)
+      expect(hasEarlier).toEqual(undefined)
+    })
+
+    it('should return data, inclusively, where year is earlier than until', () => {
+      const resp = createApiResponse()
+      const actual = filterByYear(resp, { until: 2012 })
+      const hasLater = actual['united-states'].find(y => y.year === 2014)
+      expect(hasLater).toEqual(undefined)
+    })
+
+    it('should return data, inclusively, between since and until', () => {
+      const resp = createApiResponse()
+      const actual = filterByYear(resp, { since: 2011, until: 2012 })
+      const hasYears = actual['united-states'].map(y => y.year)
+      expect(hasYears).toEqual([2011, 2012])
+    })
+  })
+
+  describe('reshapeData()', () => {
+    it('should turn array into a single object', () => {
+      const actual = reshapeData([
+        { key: 'fake-one', results: 'yoo' },
+        { key: 'fake-two', results: 'other' },
+      ])
+      expect(actual).toEqual({ 'fake-one': 'yoo', 'fake-two': 'other' })
+    })
   })
 })


### PR DESCRIPTION
Note that this PR isn't not against master, but `jk-jw-all-composite-charts` which is another in-progress feature branch.

The `mungeSummary` data function was doing quite a bit all in one call which made it require a lot of parameters and was harder to follow. It has been refactored into a series of smaller helper functions that are used at different points in the app. This way the data is reduced into a more usable form that requires no further calculation, just shape manipulation and filtering.

Added tests for all new functions in summary util