### PR TITLE
Remove small charts for violent crime or property crime

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Though unit test coverage is decent (check with `npm run coverage`, as of [`cdb2
 2. Determine if the version should be increased by a major, minor, or patch version
 3. Adjust the version number in `package.json` accordingly
 4. Submit a pull request without tagging the commit
-5. Once the pull request is merged, tag the merge commit as `vX.Y.Z` where `X`, `Y`, and `Z` reflect the same version number as the now merged change for `package.json`
+5. Once the pull request is merged, tag the merge commit (on `master`) as `vX.Y.Z` where `X`, `Y`, and `Z` reflect the same version number as the now merged change for `package.json`
 6. Push the tag to Github with `git push origin vX.Y.Z`
 
 ## Browser support

--- a/src/containers/TrendContainer.js
+++ b/src/containers/TrendContainer.js
@@ -11,10 +11,8 @@ import NoData from '../components/NoData'
 import TrendChart from '../components/trend/TrendChart'
 import TrendSourceText from '../components/trend/TrendSourceText'
 import { generateCrimeReadme } from '../util/content'
-import { crimeTypes } from '../util/offenses'
 import { getPlaceInfo } from '../util/place'
 import { combinePlaces, filterByYear } from '../util/summary'
-import { slugify } from '../util/text'
 import lookupUsa, { nationalKey } from '../util/usa'
 
 class TrendContainer extends React.Component {

--- a/src/containers/TrendContainer.js
+++ b/src/containers/TrendContainer.js
@@ -92,25 +92,16 @@ class TrendContainer extends React.Component {
     } = this.props
     const isReady = !summaries.loading
 
-    /*
-    if (!['violent-crime', 'property-crime'].includes(crime)) return null;
-    const crimeType = camelCase(crime);
-    const crimeIds = crimeTypes[crimeType].map(t => snakeCase(t.id || t));
-    const otherTrendMap = crimeIds.map(f => ({
-      id: f,
-      place,
-      since,
-      summaries,
-      until,
-    }));
-    console.log('otherTrendMap:', otherTrendMap);
-    */
-
     let otherCrimes = []
     if (crime === 'violent-crime') {
-      otherCrimes = crimeTypes.violentCrime.map(c => c.id || slugify(c))
+      otherCrimes = ['homicide', 'rape', 'robbery', 'aggravated-assault']
     } else if (crime === 'property-crime') {
-      otherCrimes = crimeTypes.propertyCrime.map(c => c.id || slugify(c))
+      otherCrimes = [
+        'arson',
+        'burglary',
+        'larceny-theft',
+        'motor-vehicle-theft',
+      ]
     }
 
     return (


### PR DESCRIPTION
The big charts in these views are for the all violent/property crime trend chart, but it is included in the offense utility. Manually mapping the component offenses for now

Current `master`:
<img width="619" alt="screen shot 2017-08-30 at 9 53 56 am" src="https://user-images.githubusercontent.com/780941/29875922-55a38d9e-8d69-11e7-9dfb-dd8ecf9da33c.png">

Changed:
<img width="591" alt="screen shot 2017-08-30 at 9 53 47 am" src="https://user-images.githubusercontent.com/780941/29875928-5d3cef64-8d69-11e7-9cb0-dbfd2ef2804c.png">

