### PR TITLE
Use a different approach for #286 (x axis tick counts)

### DIFF
--- a/src/components/XAxis.js
+++ b/src/components/XAxis.js
@@ -2,21 +2,25 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 const XAxis = ({ active, tickCt, tickSizeOuter, height, scale, showLine }) => {
+  const domain = scale.domain()
   const range = scale.range()
   const [range0, range1, k] = [range[0] + 0.5, range[range.length - 1] + 0.5, 1]
-  const domain = `M${range0},${k * tickSizeOuter}V0.5H${range1}V${k *
-    tickSizeOuter}`
+  const d = `M${range0},${k * tickSizeOuter}V0.5H${range1}V${k * tickSizeOuter}`
 
   const format = scale.tickFormat
     ? scale.tickFormat.apply(scale)
     : x => String(x)
-  let values = scale.ticks ? scale.ticks(tickCt) : scale.domain()
-  if (values.length > 10) {
-    const newValues = []
-    for (let j = 0; j < values.length; j += 2) {
-      newValues.push(values[j])
-    }
-    values = newValues
+
+  let values = []
+  if (scale.ticks) {
+    values = scale.ticks(tickCt)
+  } else {
+    // use the ends of the domain as ticks, and fill in
+    // the proper number of ticks between them
+    const every = Math.floor((domain.length - 2) / (tickCt - 2))
+    values[0] = domain[0]
+    values = domain.filter((v, i) => i % every === 0)
+    values[values.length] = domain[domain.length - 1]
   }
 
   const ticks = values.map((v, i) => {
@@ -48,7 +52,7 @@ const XAxis = ({ active, tickCt, tickSizeOuter, height, scale, showLine }) => {
       transform={`translate(0, ${height})`}
       textAnchor="middle"
     >
-      {showLine && <path className="domain" d={domain} stroke="#000" />}
+      {showLine && <path className="domain" d={d} stroke="#000" />}
       {ticks}
     </g>
   )
@@ -62,8 +66,8 @@ XAxis.defaultProps = {
 
 XAxis.propTypes = {
   active: PropTypes.object,
-  tickCt: PropTypes.number.isRequired,
-  tickSizeOuter: PropTypes.number.isRequired,
+  tickCt: PropTypes.number,
+  tickSizeOuter: PropTypes.number,
   height: PropTypes.number.isRequired,
   scale: PropTypes.func.isRequired,
   showLine: PropTypes.bool.isRequired,

--- a/src/components/XAxis.js
+++ b/src/components/XAxis.js
@@ -10,7 +10,14 @@ const XAxis = ({ active, tickCt, tickSizeOuter, height, scale, showLine }) => {
   const format = scale.tickFormat
     ? scale.tickFormat.apply(scale)
     : x => String(x)
-  const values = scale.ticks ? scale.ticks(tickCt) : scale.domain()
+  let values = scale.ticks ? scale.ticks(tickCt) : scale.domain()
+  if (values.length > 10) {
+    const newValues = []
+    for (let j = 0; j < values.length; j += 2) {
+      newValues.push(values[j])
+    }
+    values = newValues
+  }
 
   const ticks = values.map((v, i) => {
     let pos = scale(v)

--- a/src/components/agency/AgencyChart.js
+++ b/src/components/agency/AgencyChart.js
@@ -98,7 +98,6 @@ class AgencyChart extends React.Component {
         <AgencyChartDetails
           colors={colorMap}
           crime={crime}
-          f
           data={active}
           dataPrior={activePriorYear}
           keys={keys}


### PR DESCRIPTION
#1231 is a fine approach to solving 18f/crime-data-explorer#286, but I wanted to use the `tickCt` prop to keep the `<XAxis />` API consistent regardless of the type of scale passed in. I also didn't want to hardcode any lengths into the code so that it can be more flexible.

It looks fine with the default range of 10 years and the default tick count of 8:
<img width="806" alt="screen shot 2017-08-30 at 8 42 56 pm" src="https://user-images.githubusercontent.com/780941/29901118-32621ffc-8dc4-11e7-8d82-3502d2f04223.png">
`/explorer/agency/CA0010300/violent-crime`

However, it does some math to figure out how many ticks should be there (including one on each end) which can result in the ticks not being perfectly spaced:
<img width="806" alt="screen shot 2017-08-30 at 8 42 56 pm" src="https://user-images.githubusercontent.com/780941/29901095-1682a5ae-8dc4-11e7-934f-6be7b69d13a6.png">
`/explorer/agency/CA0010300/violent-crime?since=2000&until=2015`

Thoughts @jpwentz?