### PR TITLE
Animate sidebar opening and closing

### DIFF
--- a/sass/components/_glossary.scss
+++ b/sass/components/_glossary.scss
@@ -10,12 +10,20 @@
   transition: right .2s;
   width: 20rem;
 
-  &[aria-hidden=true] { right: -20rem; }
-  [aria-hidden=true] { display: none !important; }
+  &[aria-hidden=true] {
+    right: -20rem;
+  }
+
+  [aria-hidden=true] {
+    display: none !important;
+  }
 }
 
 .glossary__content {
-  ul { padding: 0; }
+  ul {
+    padding: 0;
+  }
+
   li {
     border-bottom: 1px solid $white;
     border-top: 1px solid $white;

--- a/sass/components/_layout.scss
+++ b/sass/components/_layout.scss
@@ -42,27 +42,40 @@ footer {
 }
 
 .site-sidebar {
-  display: none;
   order: -1;
 }
 
 @media #{$breakpoint-max-md} {
-  .site-sidebar.open {
+  .site-sidebar {
     bottom: 0;
     box-sizing: border-box;
-    display: block;
-    left: 0;
     max-width: 90%;
     overflow-y: auto;
     position: fixed;
     top: 0;
+    transform: translateX(-100%);
+    transition: transform .2s;
     width: $sidebar-width;
+  }
+
+  .site-sidebar.open {
+    display: block;
+    transform: translateX(0%);
     z-index: 1;
   }
 }
 
 @media #{$breakpoint-md} {
-  .site-wrapper { flex-direction: row; }
-  .site-content { flex: 1; }
-  .site-sidebar { display: block; flex: 0 0 $sidebar-width; }
+  .site-wrapper {
+    flex-direction: row;
+  }
+
+  .site-content {
+    flex: 1;
+  }
+
+  .site-sidebar {
+    display: block;
+    flex: 0 0 $sidebar-width;
+  }
 }

--- a/src/containers/SidebarContainer.js
+++ b/src/containers/SidebarContainer.js
@@ -10,11 +10,11 @@ import { getAgency, oriToState } from '../util/agencies'
 import { nationalKey } from '../util/usa'
 
 const SidebarContainer = ({
+  actions,
   agency,
   agencyData,
   ariaControls,
   crime,
-  hide,
   filters,
   isOpen,
   onChange,
@@ -25,7 +25,7 @@ const SidebarContainer = ({
       <button
         type="button"
         className="right btn p0 fs-12 caps line-height-4 black"
-        onClick={hide}
+        onClick={actions.hide}
       >
         Close
       </button>
@@ -88,7 +88,9 @@ const mapStateToProps = ({ agencies, filters, sidebar }) => {
   }
 }
 const mapDispatchToProps = dispatch => ({
-  hide: () => dispatch(hideSidebar()),
+  actions: {
+    hide: () => dispatch(hideSidebar()),
+  },
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(SidebarContainer)


### PR DESCRIPTION
Animate the opening and closing of the sidebar to match the opening and closing of the glossary component on mobile devices.

![animated-sidebar](https://user-images.githubusercontent.com/780941/30168198-ae974f00-93b6-11e7-82c6-428cfaf39628.gif)
