### PR TITLE
Change how new relic is integrated

### DIFF
--- a/manifests/production.yml
+++ b/manifests/production.yml
@@ -6,6 +6,7 @@ applications:
   buildpack: nodejs_buildpack
   memory: 512M
   domain: fr.cloud.gov
+  instances: 2
 env:
   CDE_API: 'https://api.usa.gov/crime/fbi/ucr'
 services:

--- a/newrelic.js
+++ b/newrelic.js
@@ -4,15 +4,20 @@
  * See lib/config.defaults.js in the agent distribution for a more complete
  * description of configuration variables and their potential values.
 */
-
 const cfenv = require('cfenv')
 
 const env = cfenv.getAppEnv()
-const credService = env.getService('crime-data-api-creds') || { credentials: {} }
+const credService = env.getService('crime-data-creds') || {
+  credentials: {},
+}
+
+const isProd = process.env.NODE_ENV === 'production'
+const key = credService.credentials.NEW_RELIC_API_KEY
 
 exports.config = {
-  app_name: ['crime-data-explorer'],
-  license_key: credService.credentials.NEW_RELIC_EXPLORER_KEY,
+  app_name: ['crime-data-frontend'],
+  license_key: key,
+  agent_enabled: isProd,
   logging: {
     level: 'info',
   },

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require, no-console, padded-blocks */
 
 import 'babel-polyfill'
+import 'newrelic'
 
 import http from 'axios'
 import bodyParser from 'body-parser'
@@ -26,8 +27,6 @@ import { createIssue } from './util/github'
 import history from './util/history'
 
 const isProd = process.env.NODE_ENV === 'production'
-
-if (isProd) require('newrelic')
 
 const ENV = createEnv()
 


### PR DESCRIPTION
Update a few things to make the new relic integration better:

1. Use the proper cloud.gov user-provided service to get the API key
2. Put the conditional in the config file
3. Update production to have 2 instances to avoid noisy downtime alerting