### PR TITLE
Handle home page state selection properly

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -35,8 +35,8 @@ class Home extends React.Component {
   }
 
   handleSearchClick = () => {
-    const { actions, crime, router, usState } = this.props
-    const change = { crime, place: usState, placeType: 'state' }
+    const { actions, crime, router, place } = this.props
+    const change = { crime, place, placeType: 'state' }
     actions.updateApp(change, router)
   }
 


### PR DESCRIPTION
The prop that gets passed through is place, not usState. This was causing the state to be undefined and therefore to show the national view.

Fixes #1244