### PR TITLE
Use a different service for the New Relic key

### DIFF
--- a/manifests/base.yml
+++ b/manifests/base.yml
@@ -1,5 +1,5 @@
 services:
-- crime-data-api-creds
+- crime-data-new-relic-creds
 - crime-data-feedback-creds
 - crime-data-threat-keywords
 env:


### PR DESCRIPTION
Broke production because we were accidentally sharing an
API key that the front end app was using but returning
403 errors.

Change the services so that there are fewer shared ones
between the API and the front end application.