### PR TITLE
Fix to Data Range Change Errors

### DIFF
--- a/src/components/trend/TrendChart.js
+++ b/src/components/trend/TrendChart.js
@@ -21,9 +21,10 @@ class TrendChart extends React.Component {
     super(props)
     this.state = {
       svgParentWidth: null,
-      yearSelected: props.initialYearSelected,
+      yearSelected: props.until,
     }
     this.getDimensions = throttle(this.getDimensions, 20)
+
   }
 
   componentDidMount() {

--- a/src/components/trend/TrendChart.js
+++ b/src/components/trend/TrendChart.js
@@ -24,7 +24,6 @@ class TrendChart extends React.Component {
       yearSelected: props.until,
     }
     this.getDimensions = throttle(this.getDimensions, 20)
-
   }
 
   componentDidMount() {


### PR DESCRIPTION
Current Breakage if the Year Selected in Charts is outside the range of the next date search. IE I have 2006-2016 selected as Time Period. I then change the time period to 2005-2015 it will not load in the year selected on the previous page was 2016 the charts will not load. This is a critical fix. 