### PR TITLE
•	CDE Participation About Page reporting incorrect details whether State is Incident or NIBRS State

### DIFF
--- a/public/data/ucr-program-participation.json
+++ b/public/data/ucr-program-participation.json
@@ -70,9 +70,7 @@
   },
   "georgia": {
     "srs": true,
-    "nibrs": {
-      "initial-year": 1991
-    },
+    "nibrs": false,
     "state-program": true
   },
   "hawaii": {
@@ -149,7 +147,7 @@
     "state-program": true
   },
   "michigan": {
-    "srs": true,
+    "srs": false,
     "nibrs": {
       "initial-year": 1995
     },
@@ -157,7 +155,7 @@
   },
   "minnesota": {
     "srs": true,
-    "nibrs": false,
+    "nibrs": true,
     "state-program": true
   },
   "mississippi": {
@@ -182,7 +180,7 @@
     "state-program": true
   },
   "nebraska": {
-    "srs": false,
+    "srs": true,
     "nibrs": {
       "initial-year": 1998
     },
@@ -256,7 +254,7 @@
     "state-program": true
   },
   "rhode-island": {
-    "srs": true,
+    "srs": false,
     "nibrs": {
       "initial-year": 2004
     },

--- a/public/data/ucr-program-participation.json
+++ b/public/data/ucr-program-participation.json
@@ -155,7 +155,9 @@
   },
   "minnesota": {
     "srs": true,
-    "nibrs": true,
+    "nibrs":  {
+      "initial-year": 2016
+    },
     "state-program": true
   },
   "mississippi": {


### PR DESCRIPTION
Nebraska is listed as incident data only – Nebraska has NIBRS and summary agencies reporting
Michigan is listed as NIBRS and Summary – Michigan is all NIBRS reporting
Minnesota is listed as Summary only – Minnesota is NIBRS certified and has at least one agency reporting NIBRS  in 2016
Georgia is listed as Incident and summary – Georgia is only summary reporting
Rhode Island is listed as Incident and Summary – Rhode Island is all NIBRS reporting
