### PR TITLE
Adjust NIBRS bulk download menus

### DIFF
--- a/public/data/ucr-program-participation.json
+++ b/public/data/ucr-program-participation.json
@@ -38,7 +38,8 @@
   "colorado": {
     "srs": false,
     "nibrs": {
-      "initial-year": 1992
+      "initial-year": 1992,
+      "no-data-years": [1995, 1996]
     },
     "state-program": true
   },
@@ -57,10 +58,8 @@
     "state-program": true
   },
   "washington-dc": {
-    "srs": false,
-    "nibrs": {
-      "initial-year": 2000
-    },
+    "srs": true,
+    "nibrs": false,
     "state-program": true
   },
   "florida": {
@@ -87,9 +86,7 @@
   },
   "illinois": {
     "srs": true,
-    "nibrs": {
-      "initial-year": 1993
-    },
+    "nibrs": false,
     "state-program": true
   },
   "indiana": {
@@ -102,7 +99,7 @@
   "iowa": {
     "srs": false,
     "nibrs": {
-      "initial-year": 1991
+      "initial-year": 1992
     },
     "state-program": true
   },
@@ -130,7 +127,7 @@
   "maine": {
     "srs": true,
     "nibrs": {
-      "initial-year": 2003
+      "initial-year": 2004
     },
     "state-program": true
   },
@@ -155,16 +152,12 @@
   },
   "minnesota": {
     "srs": true,
-    "nibrs":  {
-      "initial-year": 2016
-    },
+    "nibrs": false,
     "state-program": true
   },
   "mississippi": {
     "srs": true,
-    "nibrs": {
-      "initial-year": 2009
-    },
+    "nibrs": false,
     "state-program": false
   },
   "missouri": {

--- a/src/components/DownloadBulkNibrs.js
+++ b/src/components/DownloadBulkNibrs.js
@@ -33,8 +33,11 @@ class DownloadBulkNibrs extends React.Component {
     if (!this.state.place) return []
     const { nibrs } = ucrProgram[this.state.place]
     const initialYear = nibrs['initial-year']
+    const noDataYears = nibrs['no-data-years'] || []
 
-    return range(MAX_YEAR + 1 - initialYear).map(y => initialYear + y)
+    return range(MAX_YEAR + 1 - initialYear)
+      .map(y => initialYear + y)
+      .filter(y => !noDataYears.includes(y))
   }
 
   handleClick = e => {
@@ -80,11 +83,11 @@ class DownloadBulkNibrs extends React.Component {
                 <option value="Location" disabled>
                   Location
                 </option>
-                {nibrsStates.sort().map((s, i) =>
+                {nibrsStates.sort().map((s, i) => (
                   <option key={i} value={s}>
                     {lookupUsa(s).display}
-                  </option>,
-                )}
+                  </option>
+                ))}
               </select>
             </div>
             <div className="sm-col sm-col-4 px1 mb2 sm-m0">
@@ -100,11 +103,7 @@ class DownloadBulkNibrs extends React.Component {
                 <option value="Year" disabled>
                   Year
                 </option>
-                {nibrsYears.map((y, i) =>
-                  <option key={i}>
-                    {y}
-                  </option>,
-                )}
+                {nibrsYears.map((y, i) => <option key={i}>{y}</option>)}
               </select>
             </div>
             <div className="sm-col sm-col-3 px1 mb2 sm-m0">


### PR DESCRIPTION
To handle the fact that Colorado started submitting NIBRS data in 1992 but then stopped for 1995 and 1996 I added a no-data-years optional array to the UCR program participation data. These years are not included in the year drop down for bulk NIBRS downloads.

Closes https://github.com/18F/crime-data-explorer/issues/337

This doesn't really mess up any of our other views but does make the introduction text under "Incident details" less accurate. For example, Colorado did not submit incident details/NIBRS data for 1995 or 1996 but if the range 1995-2016 is selected then the sentence reads as follows:

<img width="880" alt="There were 49,190 individual robbery incidents reported to the FBI in Colorado between 1995 and 2016 by 260 law enforcement agencies reporting data." src="https://user-images.githubusercontent.com/780941/34133649-f7e63f0a-e423-11e7-9a8f-39e81220bd37.png">

Should we update that view to be more accurate? For example, we could say:

<img width="885" alt="There were 49,190 individual robbery incidents reported to the FBI in Colorado between 1995 and 2016 by 260 law enforcement agencies reporting data. Colorado did not submit incident details in 1995 or 1996." src="https://user-images.githubusercontent.com/780941/34133677-1e2cc81e-e424-11e7-85c8-6a74998d9ed0.png">

