### PR TITLE
Reflect NIBRS gap years for Alabama and Illinois

### DIFF
--- a/public/data/ucr-program-participation.json
+++ b/public/data/ucr-program-participation.json
@@ -7,7 +7,21 @@
   "alabama": {
     "srs": true,
     "nibrs": {
-      "initial-year": 1991
+      "initial-year": 1991,
+      "no-data-years": [
+        1994,
+        1995,
+        1996,
+        1997,
+        1998,
+        1999,
+        2000,
+        2001,
+        2002,
+        2003,
+        2004,
+        2005
+      ]
     },
     "state-program": true
   },
@@ -89,7 +103,20 @@
   "illinois": {
     "srs": true,
     "nibrs": {
-      "initial-year": 1993
+      "initial-year": 1993,
+      "no-data-years": [
+        1995,
+        1996,
+        1997,
+        1998,
+        1999,
+        2000,
+        2001,
+        2002,
+        2003,
+        2004,
+        2005
+      ]
     },
     "state-program": true
   },


### PR DESCRIPTION
Per the [updated comment on crime-data-explorer#337](https://github.com/18F/crime-data-explorer/issues/337#issuecomment-355460828), I updated the NIBRS download drop downs to reflect the gap years for Alabama and Illinois.

It does make me think that we should provide some explanation for why large, 10+ year gaps are missing for some states as it looks a bit like a UI error otherwise:
<img width="1091" alt="screen shot 2018-01-05 at 9 44 09 am" src="https://user-images.githubusercontent.com/780941/34613807-22ef6b5e-f1fd-11e7-8aab-313e0f789501.png">
